### PR TITLE
Update vertx.io and log4j2 dependencies (security)

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -14,7 +14,7 @@ subprojects {
     apply plugin: 'java'
 
     ext {
-        vertx_version = '3.8.3'
+        vertx_version = '3.9.2'
     }
 
     dependencies {

--- a/backend/common/build.gradle
+++ b/backend/common/build.gradle
@@ -15,7 +15,7 @@ buildscript {
 }
 
 dependencies {
-    compile "org.apache.logging.log4j:log4j-slf4j-impl:2.11.2"
+    compile "org.apache.logging.log4j:log4j-slf4j-impl:2.13.3"
 
     compile 'com.google.code.gson:gson:2.8.6'
 


### PR DESCRIPTION
[OWASP dependency-check](https://owasp.org/www-project-dependency-check/) shows issues with:
- vertx transitively:
  - jackson: CVE-2020-24616, CVE-2019-14379, CVE-2019-14439, CVE-2019-14540, CVE-2019-14892, CVE-2019-14893, CVE-2019-16335, CVE-2019-16942, CVE-2019-16943, CVE-2019-17267, CVE-2019-17531, CVE-2019-20330, CVE-2020-10672, CVE-2020-10673, CVE-2020-10968, CVE-2020-10969, CVE-2020-11111, CVE-2020-11112, CVE-2020-11113, CVE-2020-11619, CVE-2020-11620, CVE-2020-14060, CVE-2020-14061, CVE-2020-14062, CVE-2020-14195, CVE-2020-24616, CVE-2020-8840, CVE-2020-9546, CVE-2020-9547, CVE-2020-9548
  - netty: CVE-2019-20444, CVE-2019-20445, CVE-2020-11612
- log4j2: CVE-2020-9488
