### PR TITLE
feat: Provide a basic customization option for JIFA deployments

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -174,3 +174,4 @@ permitted.
 ## Contributors:
 
 Alibaba - Initial implementation
+Netflix - Basic customization hooks

--- a/README.md
+++ b/README.md
@@ -61,6 +61,66 @@ cd build/distributions && unzip jifa-0.1.zip && cd jifa-0.1
 Jifa will now be reachable at http://localhost:8102.
 ```
 
+## Customizing JIFA
+
+Some options are provided to configure JIFA without modification to the source code.
+
+### Frontend configuration
+
+Frontend can be configured at build time:
+
+```
+# the UI file management links (release, analyze, go to file manager) can be disabled
+export VUE_APP_JIFA_FILE_MGMT=false
+./gradlew build
+```
+
+### Backend customization
+
+#### Configuration options
+
+A configuration file can be specified as an environment variable.
+
+```
+export WORKER_OPTS=-Djifa.worker.config=/path/to/worker-config.json
+./bin/worker
+...
+```
+
+A sample configuration file is here:
+```
+{
+  "server.host": "0.0.0.0",
+  "server.port": 7101,
+  "server.uploadDir": "/mnt/data/uploads",
+  "api.prefix": "/jifa-api",
+  "hooks.className": "com.yourco.JifaHooksImplementation"
+}
+```
+
+If you choose to provide a configuration file, the `api.prefix` is the only required value. Otherwise,
+defaults will apply. If you do not provide a configuration, defaults will apply. For more specific
+customization, see next section.
+
+#### Overriding HTTP server, route, and file mapping
+
+The backend can be configured; JIFA has a number of hook points where it will call some code that you provide.
+
+With hooks you can:
+- Customize the HTTP server options
+- Configure HTTP server routes to add authentication, error handling, health check URLs, etc.
+- Customize the layout of heap files on the local file system.
+
+To do so, you need to set configuration to refer to a new class which provides your custom implementations.
+You can [provide the implementations by implementing this class](backend/common/src/main/java/org/eclipse/jifa/common/JifaHooks.java)
+and then updating configuration file.
+
+In the configuration file, provide a hooks class name to use it and it will be loaded at service startup. See
+the `hooks.className` key. The JAR containing your class needs to be present on the classpath. You can use
+`export WORKER_OPTS="-Djifa.worker.config=/path/to/config.json -cp /path/to/hook.jar"`.
+
+You will need to extract the `common.jar` from the build process to get access to the JifaHooks interface.
+
 ## Contributing
 If you would like to contribute to Jifa, please check out the [contributing guide][contrib] for more information.
 

--- a/README.md
+++ b/README.md
@@ -67,13 +67,10 @@ Some options are provided to configure JIFA without modification to the source c
 
 ### Frontend configuration
 
-Frontend can be configured at build time:
+Frontend can be configured by modifying the `config.js` file provided in the application webroot, in the same
+location as the `index.html` file.
 
-```
-# the UI file management links (release, analyze, go to file manager) can be disabled
-export VUE_APP_JIFA_FILE_MGMT=false
-./gradlew build
-```
+A [sample config.js file](frontend/public/config.js) is provided with JIFA which you can edit.
 
 ### Backend customization
 

--- a/backend/common/src/main/java/org/eclipse/jifa/common/JifaHooks.java
+++ b/backend/common/src/main/java/org/eclipse/jifa/common/JifaHooks.java
@@ -1,0 +1,54 @@
+/********************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ********************************************************************************/
+
+package org.eclipse.jifa.common;
+
+import io.vertx.ext.web.Router;
+import io.vertx.core.http.HttpServerOptions;
+import io.vertx.core.json.JsonObject;
+import org.eclipse.jifa.common.enums.FileType;
+
+public interface JifaHooks {
+    /* Access the server configuration at startup. This will be called by JIFA and configuration passed in.
+       This will be called once for each verticle. */
+    default void init(JsonObject config) {}
+
+    /* Provide custom http server configuration to vertx. */
+    default HttpServerOptions serverOptions() {
+        return new HttpServerOptions();
+    }
+
+    /* Access the route configuration before JIFA routes are loaded.
+       You could use this to customize redirects, authenticate, etc. */
+    default void beforeRoutes(Router router) {}
+
+    /* Access route configuration after JIFA routes are loaded.
+       You could use this to customize error handling, etc. */
+    default void afterRoutes(Router router) {}
+
+    /* Provide custom mapping for directory path, file, and index functionality. */
+    default String mapDirPath(FileType fileType, String name, String defaultPath) {
+        return defaultPath;
+    }
+    default String mapFilePath(FileType fileType, String name, String childrenName, String defaultPath) {
+        return defaultPath;
+    }
+    default String mapIndexPath(FileType fileType, String file, String defaultPath) {
+        return defaultPath;
+    }
+
+    /* An empty default configuration */
+    public class EmptyHooks implements JifaHooks {
+        // use default implementations
+    }
+}

--- a/backend/worker/src/main/java/org/eclipse/jifa/worker/Constant.java
+++ b/backend/worker/src/main/java/org/eclipse/jifa/worker/Constant.java
@@ -42,5 +42,7 @@ public interface Constant extends org.eclipse.jifa.common.Constant {
         String API_PREFIX = "api.prefix";
         String SERVER_HOST_KEY = "server.host";
         String SERVER_PORT_KEY = "server.port";
+        String SERVER_UPLOAD_DIR_KEY = "server.uploadDir";
+        String HOOKS_NAME_KEY = "hooks.className";
     }
 }

--- a/backend/worker/src/main/java/org/eclipse/jifa/worker/Global.java
+++ b/backend/worker/src/main/java/org/eclipse/jifa/worker/Global.java
@@ -14,6 +14,7 @@ package org.eclipse.jifa.worker;
 
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
+import org.eclipse.jifa.common.JifaHooks;
 import org.eclipse.jifa.worker.support.FileSupport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,9 +37,11 @@ public class Global {
 
     private static String WORKSPACE;
 
+    private static JifaHooks HOOKS;
+
     private static boolean initialized;
 
-    static synchronized void init(Vertx vertx, String host, int port, JsonObject config) {
+    static synchronized void init(Vertx vertx, String host, int port, JsonObject config, JifaHooks hooks) {
         if (initialized) {
             return;
         }
@@ -47,6 +50,7 @@ public class Global {
         HOST = host;
         PORT = port;
         CONFIG = config;
+        HOOKS = hooks;
 
         WORKSPACE = CONFIG.getString(Constant.ConfigKey.WORKSPACE, Constant.Misc.DEFAULT_WORKSPACE);
         LOGGER.debug("Workspace: {}", WORKSPACE);
@@ -70,5 +74,9 @@ public class Global {
 
     public static String workspace() {
         return WORKSPACE;
+    }
+
+    public static JifaHooks hooks() {
+        return HOOKS;
     }
 }

--- a/backend/worker/src/main/java/org/eclipse/jifa/worker/support/FileSupport.java
+++ b/backend/worker/src/main/java/org/eclipse/jifa/worker/support/FileSupport.java
@@ -214,7 +214,8 @@ public class FileSupport {
     }
 
     public static String dirPath(FileType type, String name) {
-        return dirPath(type) + File.separator + name;
+        String defaultDirPath = dirPath(type) + File.separator + name;
+        return Global.hooks().mapDirPath(type, name, defaultDirPath);
     }
 
     private static String infoFilePath(FileType type, String name) {
@@ -230,7 +231,8 @@ public class FileSupport {
     }
 
     private static String filePath(FileType type, String name, String childrenName) {
-        return dirPath(type, name) + File.separator + childrenName;
+        String defaultFilePath = dirPath(type, name) + File.separator + childrenName;
+        return Global.hooks().mapFilePath(type, name, childrenName, defaultFilePath);
     }
 
     public static String errorLogPath(FileType fileType, String file) {
@@ -245,7 +247,8 @@ public class FileSupport {
         } else {
             indexFileNamePrefix = file + '.';
         }
-        return FileSupport.filePath(fileType, file, indexFileNamePrefix + "index");
+        String defaultIndexPath = FileSupport.filePath(fileType, file, indexFileNamePrefix + "index");
+        return Global.hooks().mapIndexPath(fileType, file, defaultIndexPath);
     }
 
     public static TransferListener createTransferListener(FileType fileType, String originalName, String fileName) {

--- a/backend/worker/src/test/java/org/eclipse/jifa/worker/FakeHooks.java
+++ b/backend/worker/src/test/java/org/eclipse/jifa/worker/FakeHooks.java
@@ -1,0 +1,36 @@
+ /********************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ********************************************************************************/ 
+package org.eclipse.jifa.worker;
+
+import io.vertx.core.json.JsonObject;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.eclipse.jifa.common.JifaHooks;
+
+public class FakeHooks implements JifaHooks {
+    static AtomicInteger initTriggered = new AtomicInteger(0);
+
+    public FakeHooks() {}
+
+    @Override
+    public void init(JsonObject config) {
+        initTriggered.incrementAndGet();
+    }
+
+    public static void reset() {
+        initTriggered.set(0);
+    }
+
+    public static int countInitTriggered() {
+        return initTriggered.get();
+    }
+}

--- a/backend/worker/src/test/java/org/eclipse/jifa/worker/TestStarter.java
+++ b/backend/worker/src/test/java/org/eclipse/jifa/worker/TestStarter.java
@@ -1,0 +1,92 @@
+/********************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ********************************************************************************/
+package org.eclipse.jifa.worker;
+
+import com.google.common.io.Files;
+import com.sun.management.HotSpotDiagnosticMXBean;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.apache.commons.io.FileUtils;
+import org.eclipse.jifa.common.enums.FileType;
+import org.eclipse.jifa.common.enums.ProgressState;
+import org.eclipse.jifa.worker.Global;
+import org.eclipse.jifa.worker.Starter;
+import org.eclipse.jifa.worker.support.FileSupport;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.vertx.core.DeploymentOptions;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.io.File;
+import java.lang.management.ManagementFactory;
+
+@RunWith(VertxUnitRunner.class)
+public class TestStarter {
+
+    private static Logger LOGGER = LoggerFactory.getLogger(TestStarter.class);
+
+    @Before
+    public void setup(TestContext context) throws Exception {
+        FakeHooks.reset();
+    }
+
+    @Test
+    public void testStartupBasicConfig(TestContext context) throws Exception {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("server.port", 8888);
+        cfg.put("api.prefix", "/jifa-api");
+        
+        Async async = context.async();
+
+        Vertx vertx = Vertx.vertx();
+        vertx.deployVerticle(Starter.class.getName(),
+            new DeploymentOptions().setConfig(new JsonObject(cfg)).setInstances(1),
+            res -> {
+                context.assertTrue(res.succeeded());
+                vertx.close(res2 -> {
+                    async.complete();
+                });
+            });
+    }
+
+    @Test
+    public void testStartWithHook(TestContext context) throws Exception {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("server.port", 8888);
+        cfg.put("api.prefix", "/jifa-api");
+        cfg.put("hooks.className", FakeHooks.class.getName());
+        
+        Async async = context.async();
+
+        Vertx vertx = Vertx.vertx();
+        vertx.deployVerticle(Starter.class.getName(),
+            new DeploymentOptions().setConfig(new JsonObject(cfg)).setInstances(1),
+            res -> {
+                context.assertTrue(res.succeeded());
+                context.assertEquals(FakeHooks.countInitTriggered(), 1);
+                vertx.close(res2 -> {
+                    async.complete();
+                });
+            });
+    }
+
+}

--- a/frontend/public/config.js
+++ b/frontend/public/config.js
@@ -10,12 +10,8 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  ********************************************************************************/
-export default class JifaGlobal {
-  static prod() {
-    return process.env.NODE_ENV === 'production'
-  }
 
-  static dev() {
-    return process.env.NODE_ENV === 'development'
-  }
+var config = {
+  // enable file browsing features in the JIFA UI
+  "fileManagement": true,
 }

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -19,6 +19,7 @@
   <link rel="icon" href="<%= BASE_URL %>eclipse_incubation_vertical_png.png">
   <title data-react-helmet="true">Jifa</title>
   <meta name="description" property="og:description" content="Jifa"/>
+  <script id="config" type="text/javascript" src="config.js"></script>
 </head>
 <body>
 <noscript>

--- a/frontend/src/Jifa.js
+++ b/frontend/src/Jifa.js
@@ -18,4 +18,9 @@ export default class JifaGlobal {
   static dev() {
     return process.env.NODE_ENV === 'development'
   }
+
+  static fileManagement() {
+    // default enabled, but can be disabled by setting 'false'
+    return process.env.VUE_APP_JIFA_FILE_MGMT !== 'false'
+  }
 }

--- a/frontend/src/components/menu/AnalysisResultMenu.vue
+++ b/frontend/src/components/menu/AnalysisResultMenu.vue
@@ -12,11 +12,11 @@
  -->
 <template>
   <b-navbar-nav>
-    <b-nav-item href="#" @click="doReanalyze" v-if="analysisState === 'SUCCESS' || analysisState === 'ERROR'">
+    <b-nav-item href="#" @click="doReanalyze" v-if="$jifa.fileManagement() && (analysisState === 'SUCCESS' || analysisState === 'ERROR')">
       <i class="el-icon-warning-outline" style="margin-right: 3px"/> {{$t("jifa.reanalyze")}}
     </b-nav-item>
 
-    <b-nav-item href="#" @click="doRelease" v-if="analysisState === 'SUCCESS'">
+    <b-nav-item href="#" @click="doRelease" v-if="$jifa.fileManagement() && analysisState === 'SUCCESS'">
       <i class="el-icon-s-release" style="margin-right: 3px"/> {{$t("jifa.release")}}
     </b-nav-item>
 
@@ -49,27 +49,31 @@
     methods: {
 
       doReanalyze() {
-        this.$confirm(this.$t('jifa.heap.reanalyzePrompt'), this.$t('jifa.prompt'), {
-          confirmButtonText: this.$t('jifa.confirm'),
-          cancelButtonText: this.$t('jifa.cancel'),
-          type: 'warning'
-        }).then(() => {
-          axios.post(this.getUrlByType('clean')).then(() => {
-            window.location.reload();
+        if (this.$jifa.fileManagement()) {
+          this.$confirm(this.$t('jifa.heap.reanalyzePrompt'), this.$t('jifa.prompt'), {
+            confirmButtonText: this.$t('jifa.confirm'),
+            cancelButtonText: this.$t('jifa.cancel'),
+            type: 'warning'
+          }).then(() => {
+            axios.post(this.getUrlByType('clean')).then(() => {
+              window.location.reload();
+            })
           })
-        })
+        }
       },
 
       doRelease() {
-        this.$confirm(this.$t('jifa.heap.releasePrompt'), this.$t('jifa.prompt'), {
-          confirmButtonText: this.$t('jifa.confirm'),
-          cancelButtonText: this.$t('jifa.cancel'),
-          type: 'warning'
-        }).then(() => {
-          axios.post(this.getUrlByType('release')).then(() => {
-            this.$router.push({name: 'finder'})
+        if (this.$jifa.fileManagement()) {
+          this.$confirm(this.$t('jifa.heap.releasePrompt'), this.$t('jifa.prompt'), {
+            confirmButtonText: this.$t('jifa.confirm'),
+            cancelButtonText: this.$t('jifa.cancel'),
+            type: 'warning'
+          }).then(() => {
+            axios.post(this.getUrlByType('release')).then(() => {
+              this.$router.push({name: 'finder'})
+            })
           })
-        })
+        }
       },
 
       triggerInspector() {

--- a/frontend/src/components/menu/AnalysisResultMenu.vue
+++ b/frontend/src/components/menu/AnalysisResultMenu.vue
@@ -12,11 +12,11 @@
  -->
 <template>
   <b-navbar-nav>
-    <b-nav-item href="#" @click="doReanalyze" v-if="$jifa.fileManagement() && (analysisState === 'SUCCESS' || analysisState === 'ERROR')">
+    <b-nav-item href="#" @click="doReanalyze" v-if="$jifa.fileManagement && (analysisState === 'SUCCESS' || analysisState === 'ERROR')">
       <i class="el-icon-warning-outline" style="margin-right: 3px"/> {{$t("jifa.reanalyze")}}
     </b-nav-item>
 
-    <b-nav-item href="#" @click="doRelease" v-if="$jifa.fileManagement() && analysisState === 'SUCCESS'">
+    <b-nav-item href="#" @click="doRelease" v-if="$jifa.fileManagement && analysisState === 'SUCCESS'">
       <i class="el-icon-s-release" style="margin-right: 3px"/> {{$t("jifa.release")}}
     </b-nav-item>
 
@@ -49,31 +49,27 @@
     methods: {
 
       doReanalyze() {
-        if (this.$jifa.fileManagement()) {
-          this.$confirm(this.$t('jifa.heap.reanalyzePrompt'), this.$t('jifa.prompt'), {
-            confirmButtonText: this.$t('jifa.confirm'),
-            cancelButtonText: this.$t('jifa.cancel'),
-            type: 'warning'
-          }).then(() => {
-            axios.post(this.getUrlByType('clean')).then(() => {
-              window.location.reload();
-            })
+        this.$confirm(this.$t('jifa.heap.reanalyzePrompt'), this.$t('jifa.prompt'), {
+          confirmButtonText: this.$t('jifa.confirm'),
+          cancelButtonText: this.$t('jifa.cancel'),
+          type: 'warning'
+        }).then(() => {
+          axios.post(this.getUrlByType('clean')).then(() => {
+            window.location.reload();
           })
-        }
+        })
       },
 
       doRelease() {
-        if (this.$jifa.fileManagement()) {
-          this.$confirm(this.$t('jifa.heap.releasePrompt'), this.$t('jifa.prompt'), {
-            confirmButtonText: this.$t('jifa.confirm'),
-            cancelButtonText: this.$t('jifa.cancel'),
-            type: 'warning'
-          }).then(() => {
-            axios.post(this.getUrlByType('release')).then(() => {
-              this.$router.push({name: 'finder'})
-            })
+        this.$confirm(this.$t('jifa.heap.releasePrompt'), this.$t('jifa.prompt'), {
+          confirmButtonText: this.$t('jifa.confirm'),
+          cancelButtonText: this.$t('jifa.cancel'),
+          type: 'warning'
+        }).then(() => {
+          axios.post(this.getUrlByType('release')).then(() => {
+            this.$router.push({name: 'finder'})
           })
-        }
+        })
       },
 
       triggerInspector() {

--- a/frontend/src/components/menu/FinderMenu.vue
+++ b/frontend/src/components/menu/FinderMenu.vue
@@ -14,12 +14,12 @@
   <b-navbar-nav>
 
     <b-nav-item @click="$emit('chooseMenu', 'HEAP_DUMP')"
-                v-if="$jifa.fileManagement()"
+                v-if="$jifa.fileManagement"
                 :active="fileType==='HEAP_DUMP'">
       <i class="el-icon-coin" style="margin-right: 3px"/> {{$t("jifa.heapDumpAnalysis")}}
     </b-nav-item>
 
-    <b-nav-item @click="handleAddFile" v-if="$jifa.fileManagement()">
+    <b-nav-item @click="handleAddFile" v-if="$jifa.fileManagement">
       <i class="el-icon-plus" style="margin-right: 3px"/> {{this.title}}
     </b-nav-item>
   </b-navbar-nav>

--- a/frontend/src/components/menu/FinderMenu.vue
+++ b/frontend/src/components/menu/FinderMenu.vue
@@ -14,11 +14,12 @@
   <b-navbar-nav>
 
     <b-nav-item @click="$emit('chooseMenu', 'HEAP_DUMP')"
+                v-if="$jifa.fileManagement()"
                 :active="fileType==='HEAP_DUMP'">
       <i class="el-icon-coin" style="margin-right: 3px"/> {{$t("jifa.heapDumpAnalysis")}}
     </b-nav-item>
 
-    <b-nav-item @click="handleAddFile">
+    <b-nav-item @click="handleAddFile" v-if="$jifa.fileManagement()">
       <i class="el-icon-plus" style="margin-right: 3px"/> {{this.title}}
     </b-nav-item>
   </b-navbar-nav>

--- a/frontend/src/components/menu/ViewMenu.vue
+++ b/frontend/src/components/menu/ViewMenu.vue
@@ -13,11 +13,11 @@
 <template>
   <b-navbar type="light" variant="faded" style="height: 100%; border-bottom: 1px solid #dcdfe6; font-size: 14px">
     <b-navbar-nav>
-      <b-navbar-brand href="" to="/" v-if="$jifa.fileManagement()">
+      <b-navbar-brand href="" to="/" v-if="$jifa.fileManagement">
         <i class="el-icon-s-platform"/>
         J I F A
       </b-navbar-brand>
-      <b-navbar-brand v-if="!$jifa.fileManagement()">
+      <b-navbar-brand v-if="!$jifa.fileManagement">
         <i class="el-icon-s-platform"/>
         J I F A
       </b-navbar-brand>

--- a/frontend/src/components/menu/ViewMenu.vue
+++ b/frontend/src/components/menu/ViewMenu.vue
@@ -13,7 +13,11 @@
 <template>
   <b-navbar type="light" variant="faded" style="height: 100%; border-bottom: 1px solid #dcdfe6; font-size: 14px">
     <b-navbar-nav>
-      <b-navbar-brand href="" to="/">
+      <b-navbar-brand href="" to="/" v-if="$jifa.fileManagement()">
+        <i class="el-icon-s-platform"/>
+        J I F A
+      </b-navbar-brand>
+      <b-navbar-brand v-if="!$jifa.fileManagement()">
         <i class="el-icon-s-platform"/>
         J I F A
       </b-navbar-brand>

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -10,12 +10,12 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  ********************************************************************************/
-export default class JifaGlobal {
-  static prod() {
-    return process.env.NODE_ENV === 'production'
-  }
 
-  static dev() {
-    return process.env.NODE_ENV === 'development'
-  }
+const defaults = {
+  fileManagement: true,
+}
+
+export default {
+  ...defaults,
+  ...window.config,
 }

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -40,7 +40,7 @@ Vue.use(VueCharts)
 Vue.use(VueClipboard)
 Vue.use(contentmenu)
 Vue.use(VueCookies)
-Vue.prototype.$jifa = { ...JifaGlobal, ...config }
+Vue.prototype.$jifa = Object.assign(JifaGlobal, config)
 
 export default new Vue({
   router,

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -17,6 +17,7 @@ import JifaGlobal from './Jifa'
 
 import i18n from './i18n/i18n-setup'
 import router from './router'
+import config from './config'
 
 import ElementUI from 'element-ui'
 import BootstrapVue from 'bootstrap-vue'
@@ -39,7 +40,7 @@ Vue.use(VueCharts)
 Vue.use(VueClipboard)
 Vue.use(contentmenu)
 Vue.use(VueCookies)
-Vue.prototype.$jifa = JifaGlobal
+Vue.prototype.$jifa = { ...JifaGlobal, ...config }
 
 export default new Vue({
   router,


### PR DESCRIPTION
Provides a very basic customization layer for JIFA. This allows us to customize it for our deployments without carrying a fork of JIFA.

~~Build time configuration is available for the frontend:~~
Runtime configuration is available for the frontend:
- Disable/enable file management features of JIFA UI

Backend runtime hooks are provided for:
- Customize the HTTP server options
- Configure HTTP server routes to add authentication, error handling, health check URLs, etc.
- Customize the layout of heap files on the local file system.

