### PR TITLE
fix [Vue warn]: Avoid using non-primitive value as key, use string/number value instead

### DIFF
--- a/frontend/src/components/menu/ViewMenu.vue
+++ b/frontend/src/components/menu/ViewMenu.vue
@@ -29,7 +29,7 @@
     <b-navbar-nav v-if="subject==='finder'" class="ml-auto">
       <b-nav-item-dropdown>
         <template v-slot:button-content>{{currentLanguage}}</template>
-        <b-dropdown-item href="#" v-for="lang in supportLanguages" :key="lang"
+        <b-dropdown-item href="#" v-for="lang in supportLanguages" :key="lang.value"
                          @click="$i18n.locale=lang.value; currentLanguage=lang.label">
           {{lang.label}}
         </b-dropdown-item>


### PR DESCRIPTION
Fix the following warning in the console.

```
vue.runtime.esm.js?2b0e:619 [Vue warn]: Avoid using non-primitive value as key, use string/number value instead.

found in

---> <ViewMenu> at src/components/menu/ViewMenu.vue
       <ElHeader> at packages/header/src/main.vue
         <ElContainer> at packages/container/src/main.vue
           <Finder> at src/components/finder.vue
             <Jifa> at src/Jifa.vue
               <Root>
```

Signed-off-by: Sam Ma samuel.ma2012@gmail.com
