### PR TITLE
fix: extractFileName use url path instead of url.

### DIFF
--- a/backend/worker/src/main/java/org/eclipse/jifa/worker/route/FileRoute.java
+++ b/backend/worker/src/main/java/org/eclipse/jifa/worker/route/FileRoute.java
@@ -19,6 +19,8 @@ import io.vertx.core.http.HttpServerResponse;
 import io.vertx.ext.web.FileUpload;
 import io.vertx.ext.web.RoutingContext;
 import org.apache.logging.log4j.util.Strings;
+import org.eclipse.jifa.common.aux.ErrorCode;
+import org.eclipse.jifa.common.aux.JifaException;
 import org.eclipse.jifa.common.enums.FileType;
 import org.eclipse.jifa.common.enums.ProgressState;
 import org.eclipse.jifa.common.request.PagingRequest;
@@ -35,6 +37,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.List;
 import java.util.Set;
 
@@ -84,7 +88,13 @@ class FileRoute extends BaseRoute {
     void transferByURL(Future<TransferringFile> future, @ParamKey("type") FileType fileType,
                        @ParamKey("url") String url, @ParamKey(value = "fileName", mandatory = false) String fileName) {
 
-        String originalName = extractFileName(url);
+        String originalName;
+        try {
+            originalName = extractFileName(new URL(url).getPath());
+        } catch (MalformedURLException e) {
+            LOGGER.warn("invalid url: {}", url);
+            throw new JifaException(ErrorCode.ILLEGAL_ARGUMENT, e);
+        }
 
         fileName = Strings.isNotBlank(fileName) ? fileName : decorateFileName(originalName);
 


### PR DESCRIPTION
Hi,
when transferByURL to upload dump file. if the url like:
https:/mydomain/dump-file/heap-2020-09-24_21_46_11-10.44.203.40_0470-xWfHPh16.hprof?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20201014T0631Z&X-Amz-SignedHeaders=host&X-Amz-Expires=21600&X-Amz-Credential=JEB35GY4ZP8UUDOWKJ6Q%2F2020014%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Signature=5aae4f2b1cb27f6b05aa6fa692c4f4d4fcfd1b6dda4d08c164466a877265bb

after extractFileName, we get the fileName: heap-2020-09-24_21_46_11-10.44.203.40_0470-xWfHPh16.hprof?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20201014T0631Z&X-Amz-SignedHeaders=host&X-Amz-Expires=21600&X-Amz-Credential=JEB35GY4ZP8UUDOWKJ6Q%2F2020014%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Signature=5aae4f2b1cb27f6b05aa6fa692c4f4d4fcfd1b6dda4d08c164466a877265bb

so can't make the direction of filename.  

It's a bug.  so i fix it by using url.getPath.