### PR TITLE
fix: use mergePathToGCRoots instead of pathToGCRoot in histogram

### DIFF
--- a/backend/worker/src/main/java/org/eclipse/jifa/worker/route/heapdump/HeapBaseRoute.java
+++ b/backend/worker/src/main/java/org/eclipse/jifa/worker/route/heapdump/HeapBaseRoute.java
@@ -42,6 +42,7 @@ public class HeapBaseRoute extends BaseRoute {
         ROUTES.add(PathToGCRootsRoute.class);
         ROUTES.add(CompareRoute.class);
         ROUTES.add(LeakRoute.class);
+        ROUTES.add(MergePathToGCRootsRoute.class);
     }
 
     public static List<Class<? extends HeapBaseRoute>> routes() {

--- a/backend/worker/src/main/java/org/eclipse/jifa/worker/route/heapdump/MergePathToGCRootsRoute.java
+++ b/backend/worker/src/main/java/org/eclipse/jifa/worker/route/heapdump/MergePathToGCRootsRoute.java
@@ -1,0 +1,101 @@
+/********************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ********************************************************************************/
+package org.eclipse.jifa.worker.route.heapdump;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.eclipse.jifa.common.aux.JifaException;
+import org.eclipse.jifa.common.request.PagingRequest;
+import org.eclipse.jifa.common.util.PageViewBuilder;
+import org.eclipse.jifa.common.vo.PageView;
+import org.eclipse.jifa.worker.route.ParamKey;
+import org.eclipse.jifa.worker.route.RouteMeta;
+import org.eclipse.jifa.worker.support.Analyzer;
+import org.eclipse.jifa.worker.support.heapdump.HeapDumpSupport;
+import org.eclipse.jifa.worker.vo.heapdump.HeapObject;
+import org.eclipse.jifa.worker.vo.heapdump.gcrootpath.MergePathToGCRootsTreeNode;
+import org.eclipse.mat.SnapshotException;
+import org.eclipse.mat.internal.snapshot.inspections.MultiplePath2GCRootsQuery;
+import org.eclipse.mat.parser.model.ClassImpl;
+import org.eclipse.mat.query.Bytes;
+import org.eclipse.mat.snapshot.ISnapshot;
+import org.eclipse.mat.snapshot.model.IObject;
+
+import io.vertx.core.Future;
+
+class MergePathToGCRootsRoute extends HeapBaseRoute {
+
+    @RouteMeta(path = "/mergePathToGCRoots/roots/byClassId")
+    void rootsByClassId(Future<PageView<MergePathToGCRootsTreeNode>> future, @ParamKey("file") String file,
+            @ParamKey("classId") int classId, @ParamKey("grouping") MultiplePath2GCRootsQuery.Grouping grouping,
+            PagingRequest pagingRequest) throws Exception {
+        ISnapshot snapshot = Analyzer.getOrOpenSnapshotContext(file).getSnapshot();
+        MultiplePath2GCRootsQuery.Tree tree = buildMultiplePath2GCRootsTreeByClassId(snapshot, classId, grouping);
+        future.complete(buildRecords(snapshot, tree, pagingRequest, tree.getElements()));
+    }
+
+    @RouteMeta(path = "/mergePathToGCRoots/children/byClassId")
+    void childrenByClassId(Future<PageView<MergePathToGCRootsTreeNode>> future, @ParamKey("file") String file,
+            @ParamKey("grouping") MultiplePath2GCRootsQuery.Grouping grouping, PagingRequest pagingRequest,
+            @ParamKey("classId") int classId, @ParamKey("objectIdPathInGCPathTree") int[] objectIdPathInGCPathTree)
+            throws Exception {
+        ISnapshot snapshot = Analyzer.getOrOpenSnapshotContext(file).getSnapshot();
+        MultiplePath2GCRootsQuery.Tree tree = buildMultiplePath2GCRootsTreeByClassId(snapshot, classId, grouping);
+        Object object = HeapDumpSupport.fetchObjectInResultTree(tree, objectIdPathInGCPathTree);
+        List<?> elements = object == null ? Collections.emptyList() : tree.getChildren(object);
+        future.complete(buildRecords(snapshot, tree, pagingRequest, elements));
+    }
+
+    private MultiplePath2GCRootsQuery.Tree buildMultiplePath2GCRootsTreeByClassId(ISnapshot snapshot, int classId,
+            MultiplePath2GCRootsQuery.Grouping grouping)
+            throws Exception {
+        if (grouping != MultiplePath2GCRootsQuery.Grouping.FROM_GC_ROOTS) {
+            throw new JifaException("unsupported grouping now.");
+        }
+
+        ClassImpl clazz = (ClassImpl) snapshot.getObject(classId);
+
+        MultiplePath2GCRootsQuery multiplePath2GCRootsQuery = new MultiplePath2GCRootsQuery();
+        multiplePath2GCRootsQuery.snapshot = snapshot;
+        multiplePath2GCRootsQuery.groupBy = grouping;
+        multiplePath2GCRootsQuery.objects = HeapDumpSupport.buildHeapObjectArgument(clazz.getObjectIds());
+
+        return (MultiplePath2GCRootsQuery.Tree) multiplePath2GCRootsQuery.execute(HeapDumpSupport.VOID_LISTENER);
+    }
+
+    private PageView<MergePathToGCRootsTreeNode> buildRecords(ISnapshot snapshot,
+            MultiplePath2GCRootsQuery.Tree tree,
+            PagingRequest pagingRequest, List<?> elements) {
+        return PageViewBuilder.build(elements, pagingRequest, element -> {
+            try {
+                MergePathToGCRootsTreeNode record = new MergePathToGCRootsTreeNode();
+                int objectId = tree.getContext(element).getObjectId();
+                IObject object = snapshot.getObject(objectId);
+                record.setObjectId(tree.getContext(element).getObjectId());
+                record.setObjectType(HeapObject.Type.typeOf(object));
+                record.setGCRoot(snapshot.isGCRoot(objectId));
+                record.setClassName(tree.getColumnValue(element, 0).toString());
+                record.setSuffix(HeapDumpSupport.suffix(object.getGCRootInfo()));
+                record.setRefObjects((int) tree.getColumnValue(element, 1));
+                record.setShallowHeap(((Bytes) tree.getColumnValue(element, 2)).getValue());
+                record.setRefShallowHeap(((Bytes) tree.getColumnValue(element, 3)).getValue());
+                record.setRetainedHeap(((Bytes) tree.getColumnValue(element, 4)).getValue());
+                return record;
+            } catch (SnapshotException ex) {
+                throw new JifaException(ex);
+            }
+        });
+    }
+
+}

--- a/backend/worker/src/main/java/org/eclipse/jifa/worker/support/heapdump/HeapDumpSupport.java
+++ b/backend/worker/src/main/java/org/eclipse/jifa/worker/support/heapdump/HeapDumpSupport.java
@@ -14,6 +14,7 @@ package org.eclipse.jifa.worker.support.heapdump;
 
 import org.eclipse.mat.SnapshotException;
 import org.eclipse.mat.query.IContextObject;
+import org.eclipse.mat.query.IResultTree;
 import org.eclipse.mat.snapshot.ISnapshot;
 import org.eclipse.mat.snapshot.model.GCRootInfo;
 import org.eclipse.mat.snapshot.model.IObject;
@@ -81,5 +82,35 @@ public class HeapDumpSupport {
                 return null;
             }
         };
+    }
+
+    private static Object findObjectInTree(IResultTree tree, List<?> levelElements, int targetId) {
+        if (levelElements != null) {
+            for (Object o : levelElements) {
+                if (tree.getContext(o).getObjectId() == targetId) {
+                    return o;
+                }
+            }
+        }
+        return null;
+    }
+
+    public static Object fetchObjectInResultTree(IResultTree tree, int[] idPathInResultTree) {
+        if (idPathInResultTree == null || idPathInResultTree.length == 0) {
+            return null;
+        }
+
+        // find the object in root tree
+        Object objectInTree = findObjectInTree(tree, tree.getElements(), idPathInResultTree[0]);
+
+        // find the object in children tree
+        for (int i = 1; i < idPathInResultTree.length; i++) {
+            if (objectInTree == null) {
+                return null;
+            }
+            objectInTree = findObjectInTree(tree, tree.getChildren(objectInTree), idPathInResultTree[i]);
+        }
+
+        return objectInTree;
     }
 }

--- a/backend/worker/src/main/java/org/eclipse/jifa/worker/vo/heapdump/gcrootpath/MergePathToGCRootsTreeNode.java
+++ b/backend/worker/src/main/java/org/eclipse/jifa/worker/vo/heapdump/gcrootpath/MergePathToGCRootsTreeNode.java
@@ -1,0 +1,28 @@
+/********************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ********************************************************************************/
+package org.eclipse.jifa.worker.vo.heapdump.gcrootpath;
+
+import lombok.Data;
+
+@Data
+public class MergePathToGCRootsTreeNode {
+    private int objectId;
+    private String className;
+    private int refObjects;
+    private long shallowHeap;
+    private long refShallowHeap;
+    private long retainedHeap;
+    private String suffix;
+    private int objectType;
+    private boolean gCRoot;
+}

--- a/frontend/src/components/heapdump/DynamicResultSlot.vue
+++ b/frontend/src/components/heapdump/DynamicResultSlot.vue
@@ -38,6 +38,10 @@
               @click="$emit('pathToGCRootsOfObj', contextMenuTargetObjectId, contextMenuTargetObjectLabel)">
         {{$t('jifa.heap.pathToGCRoots')}}
       </v-contextmenu-item>
+      <v-contextmenu-item
+              @click="$emit('mergePathToGCRootsFromHistogram', contextMenuTargetObjectId, contextMenuTargetObjectLabel)">
+        {{$t('jifa.heap.mergePathToGCRoots')}}
+      </v-contextmenu-item>
     </v-contextmenu>
 
     <el-tabs v-model="editableTabsValue" type="card" closable @tab-remove="removeTab" style="height: 100%">
@@ -159,6 +163,52 @@
                          style="font-size: 25px; cursor: pointer"
                          @dblclick="loadMorePathToGCRootsOfObj(item)"></i></el-divider>
         </div>
+
+        <el-table v-if="item.isMergePathToGCRootsTab"
+                  ref='resultContainer'
+                  :data="item.tableData"
+                  :highlight-current-row="true"
+                  stripe
+                  :header-cell-style="headerCellStyle"
+                  :cell-style='cellStyle'
+                  row-key="rowKey"
+                  v-loading="item.loading"
+                  :load="item.load"
+                  height="100%"
+                  :span-method="spanMethod"
+                  :indent=8
+                  lazy
+                  fit>
+          <el-table-column label="Class Name" show-overflow-tooltip>
+            <template slot-scope="scope">
+              <img :src="scope.row.icon" style="margin-right: 5px"/>
+              {{ scope.row.label }}
+              <span style="font-weight: bold; color: #909399">
+                {{ scope.row.suffix }}
+              </span>
+              <span v-if="scope.row.isSummaryItem">
+                <img :src="ICONS.misc.sumIcon" v-if="item.records.length >= item.totalSize"/>
+                <img :src="ICONS.misc.sumPlusIcon" @dblclick="fetchMergePathToGCRootsNextPageData" style="cursor: pointer" v-else/>
+                {{ item.records.length }} <strong> / </strong> {{item.totalSize}}
+              </span>
+              <span v-if="scope.row.isChildrenSummary">
+                <img :src="ICONS.misc.sumIcon" v-if="scope.row.currentSize >= scope.row.totalSize"/>
+                <img :src="ICONS.misc.sumPlusIcon" @dblclick="fetchMergePathToGCRootsChildren(scope.row, scope.row.nextPage, scope.row.parentRowKey, scope.row.resolve)" style="cursor: pointer" v-else/>
+                        {{ scope.row.currentSize }} <strong> / </strong> {{ scope.row.totalSize }}
+              </span>
+            </template>
+          </el-table-column>
+          <el-table-column/>
+          <el-table-column/>
+          <el-table-column/>
+          <el-table-column/>
+          <el-table-column/>
+
+          <el-table-column label="Ref. Objects" prop="refObjects"></el-table-column>
+          <el-table-column label="Shallow Heap" prop="shallowHeap"></el-table-column>
+          <el-table-column label="Ref. Shallow Heap" prop="refShallowHeap"></el-table-column>
+          <el-table-column label="Retained Heap" prop="retainedHeap"></el-table-column>
+        </el-table>
       </el-tab-pane>
     </el-tabs>
   </div>
@@ -526,8 +576,174 @@
 
         this.editableTabsValue = activeName;
         this.editableTabs = tabs.filter(tab => tab.name !== targetName);
-      }
+      },
+
+      //  ============ mergePathToGCRootS methods ====================
+      spanMethod(row) {
+        let index = row.columnIndex;
+        if (index === 0) {
+          return [1, 6]
+        } else if (index >= 1 && index <= 5) {
+          return [0, 0]
+        }
+        return [1, 1]
+      },
+
+      getIconWrapper(gCRoot, objectType) {
+        if (this.grouping === 'BY_CLASS') {
+          return ICONS.objects.class
+        }
+        return getIcon(gCRoot, objectType)
+      },
+
+      mergePathToGCRootsFromHistogram(classId, label) {
+        let newTabName = ++this.tabIndex + '';
+        let newTab = this.addPathToGCRootsFromHistogramTab(
+                this.buildTitle(this.$t('jifa.heap.mergePathToGCRoots'), label), newTabName, this.loadMergePathToGCChildren, classId);
+        this.fetchMergePathToGCRootsNextPageData(newTab);
+      },
+
+      addPathToGCRootsFromHistogramTab(title, name, load, classId) {
+        this.tabIndex++;
+        let newTab = {
+          fromHistogram: true,
+          title: title,
+          name: name,
+          loading: false,
+          isMergePathToGCRootsTab: true,
+          classId: classId,
+          tableData: [],
+          load: load,
+          grouping: 'FROM_GC_ROOTS',
+          nextPage: 1,
+          pageSize: 25,
+          totalSize: 0,
+          records: [],
+        };
+        this.editableTabs.push(newTab);
+        this.editableTabsValue = name;
+        return newTab;
+      },
+
+      fetchMergePathToGCRootsNextPageData(mergePathToGCRootsTab) {
+        mergePathToGCRootsTab.loading = true;
+        let api = "";
+        let params = {};
+        if (mergePathToGCRootsTab.fromHistogram) {
+          api = 'mergePathToGCRoots/roots/byClassId';
+          params = {
+            classId: mergePathToGCRootsTab.classId,
+            page: mergePathToGCRootsTab.nextPage,
+            pageSize: mergePathToGCRootsTab.pageSize,
+            grouping: mergePathToGCRootsTab.grouping
+          }
+        }
+        axios.get(heapDumpService(this.file, api), {params: params}).then(resp => {
+          mergePathToGCRootsTab.totalSize = resp.data.totalSize;
+          let data = resp.data.data;
+          data.forEach(d => {
+            mergePathToGCRootsTab.records.push({
+              rowKey: rowKey++,
+              objectId: d.objectId,
+              icon: this.getIconWrapper(d.gCRoot, d.objectType),
+              label: d.className,
+              suffix: d.suffix,
+              refObjects: d.refObjects,
+              shallowHeap: d.shallowHeap,
+              refShallowHeap: d.refShallowHeap,
+              retainedHeap: d.retainedHeap,
+              hasChildren: true,
+              isResult: true,
+              objectIdPathInGCPathTree: [d.objectId],
+            })
+          });
+          mergePathToGCRootsTab.tableData = mergePathToGCRootsTab.records.concat({
+            rowKey: rowKey++,
+            isSummaryItem: true,
+          });
+          mergePathToGCRootsTab.nextPage++;
+          mergePathToGCRootsTab.loading = false;
+        })
+      },
+
+      loadMergePathToGCChildren(tree, treeNode, resolve) {
+        this.fetchMergePathToGCRootsChildren(tree, 1, tree.rowKey, resolve);
+      },
+
+      fetchMergePathToGCRootsChildren(row, page, parentRowKey, resolve) {
+        let index = this.currentIndex();
+        let tab = this.editableTabs[index];
+        let table = this.$refs.resultContainer[index];
+        tab.loading = true;
+
+        let api = "";
+        let params = {};
+        if (tab.fromHistogram) {
+          api = 'mergePathToGCRoots/children/byClassId';
+          params = {
+            classId: tab.classId,
+            objectIdPathInGCPathTree: JSON.stringify(row.objectIdPathInGCPathTree),
+            page: page,
+            pageSize: tab.pageSize,
+            grouping: tab.grouping
+          };
+        }
+
+        axios.get(heapDumpService(this.file, api), {params: params}).then(resp => {
+          let loadedLen = 0;
+          let loaded = table.store.states.lazyTreeNodeMap[parentRowKey];
+          let callResolve = false;
+          if (loaded) {
+            loadedLen = loaded.length;
+            if (loadedLen > 0) {
+              loaded.splice(--loadedLen, 1)
+            }
+          } else {
+            loaded = [];
+            callResolve = true;
+          }
+
+          let res = resp.data.data;
+          res.forEach(d => {
+            let objectIdPathInGCPathTreeCopy = Array.from(row.objectIdPathInGCPathTree);
+            objectIdPathInGCPathTreeCopy.push(d.objectId);
+            loaded.push({
+              rowKey: rowKey++,
+              objectId: d.objectId,
+              icon: this.getIconWrapper(d.gCRoot, d.objectType),
+              label: d.className,
+              suffix: d.suffix,
+              refObjects: d.refObjects,
+              shallowHeap: d.shallowHeap,
+              refShallowHeap: d.refShallowHeap,
+              retainedHeap: d.retainedHeap,
+              hasChildren: true,
+              isResult: true,
+              objectIdPathInGCPathTree: objectIdPathInGCPathTreeCopy,
+            });
+          });
+
+          loaded.push({
+            rowKey: rowKey++,
+            objectId: row.objectId,
+            parentRowKey: parentRowKey,
+            isChildrenSummary: true,
+            nextPage: page + 1,
+            currentSize: loadedLen + res.length,
+            totalSize: resp.data.totalSize,
+            resolve: resolve,
+            objectIdPathInGCPathTree: row.objectIdPathInGCPathTree,
+          });
+
+          if (callResolve) {
+            resolve(loaded)
+          }
+
+          tab.loading = false
+        })
+      },
     },
+
     watch: {
       editableTabs() {
         if (this.editableTabs.length === 0) {

--- a/frontend/src/components/heapdump/HeapDump.vue
+++ b/frontend/src/components/heapdump/HeapDump.vue
@@ -117,6 +117,7 @@
                                @outgoingRefsOfClass="outgoingRefsOfClass"
                                @incomingRefsOfClass="incomingRefsOfClass"
                                @pathToGCRootsOfObj="pathToGCRootsOfObj"
+                               @mergePathToGCRootsFromHistogram="mergePathToGCRootsFromHistogram"
                                @setSelectedObjectId="setSelectedObjectId"/>
                   </div>
                 </el-tab-pane>
@@ -200,7 +201,8 @@
                                          @incomingRefsOfObj="incomingRefsOfObj"
                                          @outgoingRefsOfClass="outgoingRefsOfClass"
                                          @incomingRefsOfClass="incomingRefsOfClass"
-                                         @pathToGCRootsOfObj="pathToGCRootsOfObj"/>
+                                         @pathToGCRootsOfObj="pathToGCRootsOfObj"
+                                         @mergePathToGCRootsFromHistogram="mergePathToGCRootsFromHistogram"/>
                   </div>
                 </el-tab-pane>
               </el-tabs>
@@ -372,6 +374,11 @@
 
       pathToGCRootsOfObj(id, label) {
         this.$refs['dynamicResultSlot'].pathToGCRootsOfObj(id, label);
+        this.enableShowDynamicResultSlot();
+      },
+
+      mergePathToGCRootsFromHistogram(id, label) {
+        this.$refs['dynamicResultSlot'].mergePathToGCRootsFromHistogram(id, label);
         this.enableShowDynamicResultSlot();
       },
 

--- a/frontend/src/components/heapdump/Histogram.vue
+++ b/frontend/src/components/heapdump/Histogram.vue
@@ -35,8 +35,8 @@
       </v-contextmenu-submenu>
       <v-contextmenu-item divider/>
       <v-contextmenu-item
-              @click="$emit('pathToGCRootsOfObj', contextMenuTargetObjectId, contextMenuTargetObjectLabel)">
-        {{$t('jifa.heap.pathToGCRoots')}}
+              @click="$emit('mergePathToGCRootsFromHistogram', contextMenuTargetObjectId, contextMenuTargetObjectLabel)">
+        {{$t('jifa.heap.mergePathToGCRoots')}}
       </v-contextmenu-item>
     </v-contextmenu>
 

--- a/frontend/src/i18n/cn.js
+++ b/frontend/src/i18n/cn.js
@@ -111,6 +111,7 @@ exports.default = {
       },
 
       pathToGCRoots: 'GC 根路径',
+      mergePathToGCRoots: '合并GC 根路径',
     },
   }
 };

--- a/frontend/src/i18n/en.js
+++ b/frontend/src/i18n/en.js
@@ -113,6 +113,7 @@ exports.default = {
       },
 
       pathToGCRoots: 'Path to GC Roots',
+      mergePathToGCRoots: 'Merge Path to GC Roots',
     },
   }
 };


### PR DESCRIPTION
We found something different when compare Jifa and Eclipse MAT about  pathToGCRoots in histogram view .
The root cause is Jifa use pathToGCRoot api but actually shoud use mergePathToGCRoots.

Jifa shows below:
![image](https://user-images.githubusercontent.com/13176022/102234036-d5eaa380-3f2b-11eb-95a4-ff0fcf607cb3.png)
![image](https://user-images.githubusercontent.com/13176022/102234117-edc22780-3f2b-11eb-9171-c28d18d3343a.png)

Eclipse MAT shows below:
![image](https://user-images.githubusercontent.com/13176022/102234216-08949c00-3f2c-11eb-81c2-3a4e54fb9864.png)

so, i think it's a bug need to fix.
After the fix shows below:
![image](https://user-images.githubusercontent.com/13176022/102234521-55787280-3f2c-11eb-8cdc-08ec4b454a2f.png)
![image](https://user-images.githubusercontent.com/13176022/102234625-6d4ff680-3f2c-11eb-97f3-7d6a303eb762.png)
