### PR TITLE
Eclipse OSGI fixes rebased

### DIFF
--- a/backend/heap-dump-analyzer/build.gradle
+++ b/backend/heap-dump-analyzer/build.gradle
@@ -47,17 +47,17 @@ p2AsMaven {
 }
 
 task copyMATJar(type: Copy) {
-    from "${project.rootDir}/backend/heap-dump-analyzer/build/p2asmaven/p2/eclipse-deps/plugins"
-    from "${project.rootDir}/backend/heap-dump-analyzer/build/p2asmaven/p2/eclipse-mat/plugins"
-    from "${project.rootDir}/backend/heap-dump-analyzer/build/p2asmaven/token-eclipse-mat"
-    into "${project.rootDir}/mat-deps"
+    from "${rootProject.rootDir}/backend/heap-dump-analyzer/build/p2asmaven/p2/eclipse-deps/plugins"
+    from "${rootProject.rootDir}/backend/heap-dump-analyzer/build/p2asmaven/p2/eclipse-mat/plugins"
+    from "${rootProject.rootDir}/backend/heap-dump-analyzer/build/p2asmaven/token-eclipse-mat"
+    into "${rootProject.rootDir}/mat-deps"
     include '*.jar'
     rename '(.+)_(.+)', '$1.jar'
 }
 
 task copyImplJar(type: Copy) {
     from 'impl/build/libs/impl-1.0.jar'
-    into "${project.rootDir}/mat-deps"
+    into "${rootProject.rootDir}/mat-deps"
 }
 
 copyImplJar.dependsOn(':backend:heap-dump-analyzer:impl:build')

--- a/backend/heap-dump-analyzer/impl/build.gradle
+++ b/backend/heap-dump-analyzer/impl/build.gradle
@@ -33,11 +33,11 @@ dependencies {
 
     compileOnly project(':backend:worker')
 
-    compileOnly files("${project.rootDir}/mat-deps/org.eclipse.osgi.jar" as String)
-    compileOnly files("${project.rootDir}/mat-deps/org.eclipse.equinox.registry.jar" as String)
+    compileOnly files("${rootProject.rootDir}/mat-deps/org.eclipse.osgi.jar" as String)
+    compileOnly files("${rootProject.rootDir}/mat-deps/org.eclipse.equinox.registry.jar" as String)
 
-    compileOnly files("${project.rootDir}/mat-deps/org.eclipse.mat.report.jar" as String)
-    compileOnly files("${project.rootDir}/mat-deps/org.eclipse.mat.api.jar" as String)
-    compileOnly files("${project.rootDir}/mat-deps/org.eclipse.mat.parser.jar" as String)
-    compileOnly files("${project.rootDir}/mat-deps/org.eclipse.mat.hprof.jar" as String)
+    compileOnly files("${rootProject.rootDir}/mat-deps/org.eclipse.mat.report.jar" as String)
+    compileOnly files("${rootProject.rootDir}/mat-deps/org.eclipse.mat.api.jar" as String)
+    compileOnly files("${rootProject.rootDir}/mat-deps/org.eclipse.mat.parser.jar" as String)
+    compileOnly files("${rootProject.rootDir}/mat-deps/org.eclipse.mat.hprof.jar" as String)
 }

--- a/backend/heap-dump-analyzer/impl/src/main/java/org/eclipse/jifa/hda/impl/HeapDumpAnalyzerImpl.java
+++ b/backend/heap-dump-analyzer/impl/src/main/java/org/eclipse/jifa/hda/impl/HeapDumpAnalyzerImpl.java
@@ -1758,7 +1758,7 @@ public class HeapDumpAnalyzerImpl implements HeapDumpAnalyzer<AnalysisContextImp
             IResultTree tree = queryByCommand(context, "dominator_tree -groupBy " + groupBy.name(), args);
             switch (groupBy) {
                 case NONE:
-                    Object parent = Helper.fetchObjectInResultTree(tree, idPathInResultTree);
+                    Object parent = Helper.fetchObjectInResultTree(tree, new int[]{parentObjectId});
                     return
                         buildDefaultItems(context.snapshot, tree, tree.getChildren(parent), ascendingOrder, sortBy,
                                           null, null, new PagingRequest(page, pageSize));

--- a/backend/worker/build.gradle
+++ b/backend/worker/build.gradle
@@ -28,7 +28,7 @@ dependencies {
 
     compile 'com.amazonaws:aws-java-sdk-s3:1.11.882'
 
-    compile files("${project.rootDir}/mat-deps/org.eclipse.osgi.jar" as String)
+    compile files("${rootProject.rootDir}/mat-deps/org.eclipse.osgi.jar" as String)
 
     testCompile 'junit:junit:4.12'
     testCompile group: 'io.vertx', name: 'vertx-unit', version: "${vertx_version}"

--- a/backend/worker/build.gradle
+++ b/backend/worker/build.gradle
@@ -42,6 +42,7 @@ compileJava {
 
 test {
     useJUnit()
+    systemProperty "mat-deps", "${rootProject.rootDir}/mat-deps"
 }
 
 applicationDefaultJvmArgs = ["-Dmat-deps=${rootProject.rootDir}/mat-deps"]

--- a/backend/worker/src/main/java/org/eclipse/jifa/worker/support/hda/AnalysisEnv.java
+++ b/backend/worker/src/main/java/org/eclipse/jifa/worker/support/hda/AnalysisEnv.java
@@ -16,6 +16,7 @@ import org.eclipse.jifa.common.aux.JifaException;
 import org.eclipse.jifa.hda.api.AnalysisContext;
 import org.eclipse.jifa.hda.api.HeapDumpAnalyzer;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.wiring.BundleRevision;
 import org.osgi.framework.BundleException;
 import org.osgi.framework.Constants;
 import org.osgi.framework.launch.Framework;
@@ -76,7 +77,9 @@ public class AnalysisEnv {
             }
 
             for (Bundle bundle : bundles) {
-                bundle.start();
+                if (!isFragment(bundle)) {
+                    bundle.start();
+                }
             }
         } catch (BundleException be) {
             throw new JifaException(be);
@@ -88,4 +91,7 @@ public class AnalysisEnv {
         assert HEAP_DUMP_ANALYZER != null;
     }
 
+    static boolean isFragment(Bundle bundle) {
+        return (bundle.adapt(BundleRevision.class).getTypes() & BundleRevision.TYPE_FRAGMENT) != 0;
+    }
 }

--- a/backend/worker/src/test/java/org/eclipse/jifa/worker/route/TestRoutes.java
+++ b/backend/worker/src/test/java/org/eclipse/jifa/worker/route/TestRoutes.java
@@ -60,9 +60,14 @@ public class TestRoutes {
 
     @After
     public void tearDown(TestContext context) {
+        System.out.println(context);
         try {
-            System.out.println(context);
             FileUtils.deleteDirectory(new File(WorkerGlobal.workspace()));
+        } catch (Throwable t) {
+            LOGGER.error("Error", t);
+        }
+
+        try {
             WorkerGlobal.VERTX.close(context.asyncAssertSuccess());
         } catch (Throwable t) {
             LOGGER.error("Error", t);


### PR DESCRIPTION
Use `rootProject.rootDir` instead of `project.rootDir`.
Use valid object id `parentObjectId` in `/dominatorTree/children`
Check if a loadable bundle is not a fragment before starting it.