### PR TITLE
feat: expand hooks interface with vertx parameter, to support vertx 4.x change

### DIFF
--- a/backend/common/src/main/java/org/eclipse/jifa/common/JifaHooks.java
+++ b/backend/common/src/main/java/org/eclipse/jifa/common/JifaHooks.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.jifa.common;
 
+import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpServerOptions;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.Router;
@@ -25,18 +26,18 @@ public interface JifaHooks {
     }
 
     /* Provide custom http server configuration to vertx. */
-    default HttpServerOptions serverOptions() {
+    default HttpServerOptions serverOptions(Vertx vertx) {
         return new HttpServerOptions();
     }
 
     /* Access the route configuration before JIFA routes are loaded.
        You could use this to customize redirects, authenticate, etc. */
-    default void beforeRoutes(Router router) {
+    default void beforeRoutes(Vertx vertx, Router router) {
     }
 
     /* Access route configuration after JIFA routes are loaded.
        You could use this to customize error handling, etc. */
-    default void afterRoutes(Router router) {
+    default void afterRoutes(Vertx vertx, Router router) {
     }
 
     /* Provide custom mapping for directory path, file, and index functionality. */

--- a/backend/worker/src/main/java/org/eclipse/jifa/worker/Worker.java
+++ b/backend/worker/src/main/java/org/eclipse/jifa/worker/Worker.java
@@ -123,7 +123,7 @@ public class Worker extends AbstractVerticle {
         vertx.executeBlocking(event -> {
             WorkerGlobal.init(vertx, host, port, config(), hooks);
 
-            HttpServer server = vertx.createHttpServer(hooks.serverOptions());
+            HttpServer server = vertx.createHttpServer(hooks.serverOptions(vertx));
             Router router = Router.router(vertx);
 
             // body handler always ends to be first so it can read the body
@@ -133,7 +133,7 @@ public class Worker extends AbstractVerticle {
                 router.post().handler(BodyHandler.create(uploadDir));
             }
 
-            hooks.beforeRoutes(router);
+            hooks.beforeRoutes(vertx, router);
 
             File webRoot = new File(staticRoot);
             if (webRoot.exists() && webRoot.isDirectory()) {
@@ -159,7 +159,7 @@ public class Worker extends AbstractVerticle {
             router.post().handler(BodyHandler.create());
 
             new RouteFiller(router).fill();
-            hooks.afterRoutes(router);
+            hooks.afterRoutes(vertx, router);
             server.requestHandler(router);
 
             server.listen(port, host, ar -> {


### PR DESCRIPTION
In vertx 4.x migration, it indicates `ErrorHandler` requires `vertx` object passed in. In our case, we set up error handling during hooks stage, so we need the `vertx` object passed in.
https://vert-x3.github.io/vertx-4-migration-guide/index.html#changes-in-vertx-config_changes-in-common-components