### PR TITLE
Collect DominatorTree item data only on-demand for paging

### DIFF
--- a/backend/common/src/main/java/org/eclipse/jifa/common/util/AccessorBasedTypeAdaptor.java
+++ b/backend/common/src/main/java/org/eclipse/jifa/common/util/AccessorBasedTypeAdaptor.java
@@ -1,0 +1,73 @@
+/********************************************************************************
+* Copyright (c) 2021 Contributors to the Eclipse Foundation
+*
+* See the NOTICE file(s) distributed with this work for additional
+* information regarding copyright ownership.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0
+*
+* SPDX-License-Identifier: EPL-2.0
+********************************************************************************/
+
+/**
+* @plasma147 provided this solution:
+* https://stackoverflow.com/a/11385215/813561
+* https://creativecommons.org/licenses/by-sa/3.0/
+*/
+
+package org.eclipse.jifa.common.util;
+
+import java.io.IOException;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import com.google.common.base.CaseFormat;
+import com.google.gson.Gson;
+import com.google.gson.TypeAdapter;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+import org.eclipse.jifa.common.aux.JifaException;
+
+public class AccessorBasedTypeAdaptor<T> extends TypeAdapter<T> {
+    private Gson gson;
+
+    public AccessorBasedTypeAdaptor(Gson gson) {
+        this.gson = gson;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public void write(JsonWriter out, T value) throws IOException {
+        out.beginObject();
+        for (Method method : value.getClass().getMethods()) {
+            boolean nonBooleanAccessor = method.getName().startsWith("get");
+            boolean booleanAccessor = method.getName().startsWith("is");
+            if ((nonBooleanAccessor || booleanAccessor) && !method.getName().equals("getClass") && method.getParameterTypes().length == 0) {
+                try {
+                    String name = method.getName().substring(nonBooleanAccessor ? 3 : 2);
+                    name = CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_CAMEL, name);
+                    Object returnValue = method.invoke(value);
+                    if(returnValue != null) {
+                        TypeToken<?> token = TypeToken.get(returnValue.getClass());
+                        TypeAdapter adapter = gson.getAdapter(token);
+                        out.name(name);
+                        adapter.write(out, returnValue);
+                    }
+                } catch (Exception e) {
+                    throw new JifaException(e);
+                }
+            }
+        }
+        out.endObject();
+    }
+
+    @Override
+    public T read(JsonReader in) throws IOException {
+        throw new UnsupportedOperationException("Only supports writes.");
+    }
+}

--- a/backend/common/src/main/java/org/eclipse/jifa/common/util/TypeFactory.java
+++ b/backend/common/src/main/java/org/eclipse/jifa/common/util/TypeFactory.java
@@ -1,0 +1,37 @@
+/********************************************************************************
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ********************************************************************************/
+
+/**
+ * @plasma147 provided this solution:
+ * https://stackoverflow.com/a/11385215/813561
+ * https://creativecommons.org/licenses/by-sa/3.0/
+ */
+
+package org.eclipse.jifa.common.util;
+
+import com.google.gson.Gson;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.reflect.TypeToken;
+
+public class TypeFactory implements TypeAdapterFactory {
+    @SuppressWarnings("unchecked")
+    public <T> TypeAdapter<T> create(final Gson gson, final TypeToken<T> type) {
+        Class<? super T> t = type.getRawType();
+        if(t.isAnnotationPresent(UseAccessor.class)) { 
+            return (TypeAdapter<T>) new AccessorBasedTypeAdaptor(gson);
+        } else {
+            return null;
+        }
+    }
+}

--- a/backend/common/src/main/java/org/eclipse/jifa/common/util/UseAccessor.java
+++ b/backend/common/src/main/java/org/eclipse/jifa/common/util/UseAccessor.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -10,13 +10,16 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  ********************************************************************************/
+
 package org.eclipse.jifa.common.util;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
-public class GsonHolder {
-
-    public static final Gson GSON = new GsonBuilder().registerTypeAdapterFactory(new TypeFactory()).create();
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface UseAccessor {
 
 }

--- a/backend/heap-dump-analyzer/impl/src/main/java/org/eclipse/jifa/hda/impl/VirtualDefaultItem.java
+++ b/backend/heap-dump-analyzer/impl/src/main/java/org/eclipse/jifa/hda/impl/VirtualDefaultItem.java
@@ -1,0 +1,90 @@
+/********************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ********************************************************************************/
+
+package org.eclipse.jifa.hda.impl;
+
+import org.eclipse.mat.SnapshotException;
+import org.eclipse.mat.query.Bytes;
+import org.eclipse.mat.query.IStructuredResult;
+import org.eclipse.mat.snapshot.ISnapshot;
+import org.eclipse.mat.snapshot.model.IObject;
+import org.eclipse.jifa.common.util.UseAccessor;
+import org.eclipse.jifa.hda.api.AnalysisException;
+import static org.eclipse.jifa.hda.api.Model.DominatorTree;
+
+@UseAccessor
+public class VirtualDefaultItem extends DominatorTree.DefaultItem {
+    transient final ISnapshot snapshot;
+    transient final IStructuredResult results;
+    transient final Object e;
+    transient final int labelColumn;
+    transient final int shallowColumn;
+    transient final int retainedColumn;
+    transient final int percentColumn;
+
+    public VirtualDefaultItem(final ISnapshot snapshot, final IStructuredResult results, final Object e,
+            final int labelColumn, final int shallowColumn, final int retainedColumn, final int percentColumn) {
+        this.snapshot = snapshot;
+        this.results = results;
+        this.e = e;
+        this.objectId = results.getContext(e).getObjectId();
+        this.labelColumn = labelColumn;
+        this.shallowColumn = shallowColumn;
+        this.retainedColumn = retainedColumn;
+        this.percentColumn = percentColumn;
+    }
+
+    @Override
+    public String getSuffix() {
+        try {
+            IObject object = snapshot.getObject(objectId);
+            return Helper.suffix(object.getGCRootInfo());
+        } catch (SnapshotException se) {
+            throw new AnalysisException(se);
+        }
+    }
+
+    @Override
+    public int getObjectType() {
+        try {
+            return HeapDumpAnalyzerImpl.typeOf(snapshot.getObject(objectId));
+        } catch (SnapshotException se) {
+            throw new AnalysisException(se);
+        }
+    }
+
+    @Override
+    public boolean isGCRoot() {
+        return snapshot.isGCRoot(objectId);
+    }
+
+    @Override
+    public String getLabel() {
+        return (String) results.getColumnValue(e, labelColumn);
+    }
+
+    @Override
+    public long getShallowSize() {
+        return ((Bytes) results.getColumnValue(e, shallowColumn)).getValue();
+    }
+
+    @Override
+    public long getRetainedSize() {
+        return ((Bytes) results.getColumnValue(e, retainedColumn)).getValue();
+    }
+
+    @Override
+    public double getPercent() {
+        return (Double) results.getColumnValue(e, percentColumn);
+    }
+}


### PR DESCRIPTION
Current paging logic in `PageViewBuilder` enforces map -> filter -> sort -> paging output. This is correct since paging must occur after filter and sort, and filter and sort require data provided by map. But, it means any data collected during map phase is held for filter and sort, even if the data will be thrown away during paging (for ex, `label` is collected for _every_ item in dominatortree despite only 25 entries will show it).

This PR introduces a `VirtualDefaultItem` that acts like a `DefaultItem` but loads its contents on-demand from the results tree.  Results in significant 10x improvement on displaying DominatorTree for larger heaps.

--

- Also introduces GSON components to use getXxx() for parameters when `@UseAccessor` is added to a class. An alternative would be to use a different JSON serializer.

- I see that `DefaultItem` is only used for this view, so perhaps we can completely replace the `DefaultItem` and others in the implementation in `Model.java`; however I am not sure if there is some future plans you had here. Probably a single `Item` could act in place for all items, which is why [I have parametrized the column](https://github.com/eclipse/jifa/compare/master...jasonk000:virtualize-list-generation?expand=1#diff-e876132519bd83551a87d8c30bd9dc87b0459619999654a052e35e3cbda103daR60) values.