### PR TITLE
fix: NPE on DominatorTree when sorted by Objects and grouping NONE

### DIFF
--- a/frontend/src/components/heapdump/DominatorTree.vue
+++ b/frontend/src/components/heapdump/DominatorTree.vue
@@ -194,6 +194,10 @@
         this.records = []
       },
       changeGrouping() {
+        // sort by Objects is not valid for grouping by none
+        if (this.grouping === 'NONE' && this.sortBy === 'Objects') {
+          this.sortBy = 'retainedHeap'
+        }
         this.clear()
         this.fetchNextPageData()
       },


### PR DESCRIPTION
Fixes NullPointerException in DominatorTree view

Steps to reproduce:
1. open heapdump, go to DominatorTree
2. click Package view. Sort by '# Objects'.
3. click radio to change grouping to Object (NONE)
4. NPE is returned as backend cannot sort by Objects.

Fix:
Fixes this issue by resetting the sortBy if the grouping is changed to the NONE grouping.