### PR TITLE
feat: support MAT 572596 max locals retained heap in thread info view

### DIFF
--- a/backend/heap-dump-analyzer/api/src/main/java/org/eclipse/jifa/hda/api/Model.java
+++ b/backend/heap-dump-analyzer/api/src/main/java/org/eclipse/jifa/hda/api/Model.java
@@ -400,9 +400,12 @@ public interface Model {
 
             public boolean firstNonNativeFrame;
 
-            public StackFrame(String stack, boolean hasLocal) {
+            public long maxLocalsRetainedSize;
+
+            public StackFrame(String stack, boolean hasLocal, long maxLocalsRetainedSize) {
                 this.stack = stack;
                 this.hasLocal = hasLocal;
+                this.maxLocalsRetainedSize = maxLocalsRetainedSize;
             }
         }
     }

--- a/frontend/src/components/heapdump/Thread.vue
+++ b/frontend/src/components/heapdump/Thread.vue
@@ -100,6 +100,8 @@
       </el-table-column>
       <el-table-column label="Retained Heap" prop="retainedHeap" sortable="custom">
       </el-table-column>
+      <el-table-column label="Max Locals' Retained Heap" prop="maxLocalsRetainedHeap">
+      </el-table-column>
       <el-table-column label="Context Class Loader" prop="contextClassLoader" width="420px" show-overflow-tooltip
                        sortable="custom">
       </el-table-column>
@@ -271,6 +273,7 @@
               stack: res[i].stack,
               depth: depth++,
               hasChildren: res[i].hasLocal,
+              maxLocalsRetainedHeap: res[i].maxLocalsRetainedSize,
               firstNonNativeFrame: res[i].firstNonNativeFrame
             })
           }


### PR DESCRIPTION
In MAT the query dependency for `thread_info` now includes an extra field for Max Locals' Retained Heap that displays the max heap size for any locals present in the stack frame. We have to detect this situation and send back an appropriate result. In addition, we display it to the user. Not sortable as the value is only present for stack frames (not to the threads), so there is no sortable element at the top level.

![image](https://user-images.githubusercontent.com/3196528/120377154-99d8ae80-c2d1-11eb-8ef0-24edff7007b4.png)

More details here: https://bugs.eclipse.org/bugs/show_bug.cgi?id=572596