### PR TITLE
MAT Calcite Plugin inclusion

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -67,7 +67,7 @@ def deps_dir_path = project(HEAP_DUMP_ANALYZER_ECLIPSE_MAT_DEPS).projectDir.pare
             ext {
                 mat_deps_dir_name = deps_dir_name
                 mat_deps_dir_path = deps_dir_path
-                osgi_jar = "org.eclipse.osgi.jar"
+                osgi_jar = "org.eclipse.osgi_3.16.100.v20201030-1916.jar"
             }
         }
 }

--- a/backend/heap-dump-analyzer/api/src/main/java/org/eclipse/jifa/hda/api/HeapDumpAnalyzer.java
+++ b/backend/heap-dump-analyzer/api/src/main/java/org/eclipse/jifa/hda/api/HeapDumpAnalyzer.java
@@ -102,6 +102,8 @@ public interface HeapDumpAnalyzer<C extends AnalysisContext> {
 
     OQLResult getOQLResult(C context, String oql, String sortBy, boolean ascendingOrder, int page, int pageSize);
 
+    CalciteSQLResult getCalciteSQLResult(C context, String sql, String sortBy, boolean ascendingOrder, int page, int pageSize);
+
     Model.Thread.Summary getSummaryOfThreads(C context, String searchText, SearchType searchType);
 
     PageView<Model.Thread.Item> getThreads(C context, String sortBy, boolean ascendingOrder, String searchText,

--- a/backend/heap-dump-analyzer/api/src/main/java/org/eclipse/jifa/hda/api/Model.java
+++ b/backend/heap-dump-analyzer/api/src/main/java/org/eclipse/jifa/hda/api/Model.java
@@ -410,6 +410,70 @@ public interface Model {
         }
     }
 
+    interface CalciteSQLResult {
+
+        int TREE = 1;
+
+        int TABLE = 2;
+
+        int TEXT = 3;
+
+        int getType();
+
+        @Data
+        class TableResult implements CalciteSQLResult {
+            public int type = TABLE;
+
+            public List<String> columns;
+
+            public PageView<Entry> pv;
+
+            public TableResult(List<String> columns, PageView<Entry> pv) {
+                this.columns = columns;
+                this.pv = pv;
+            }
+
+            @Data
+            public static class Entry {
+
+                public int objectId;
+
+                public List<Object> values;
+
+                public Entry(int objectId, List<Object> values) {
+                    this.objectId = objectId;
+                    this.values = values;
+                }
+            }
+
+        }
+
+        @Data
+        class TextResult implements CalciteSQLResult {
+
+            public int type = CalciteSQLResult.TEXT;
+
+            public String text;
+
+            public TextResult(String text) {
+                this.text = text;
+            }
+        }
+
+        @Data
+        class TreeResult implements CalciteSQLResult {
+
+            public PageView<JavaObject> pv;
+
+            public int type = TREE;
+
+            public TreeResult(PageView<JavaObject> pv) {
+                this.pv = pv;
+            }
+        }
+
+    }
+
     interface OQLResult {
 
         int TREE = 1;

--- a/backend/heap-dump-analyzer/eclipse-mat-deps/build.gradle
+++ b/backend/heap-dump-analyzer/eclipse-mat-deps/build.gradle
@@ -92,6 +92,7 @@ afterEvaluate {
                 "${buildDir}/p2asmaven/p2/eclipse-mat/plugins",
                 )
         into "${mat_deps_dir_path}"
+        duplicatesStrategy = DuplicatesStrategy.WARN
         include '*.jar'
         rename '(.+)', '$1'
     }

--- a/backend/heap-dump-analyzer/eclipse-mat-deps/build.gradle
+++ b/backend/heap-dump-analyzer/eclipse-mat-deps/build.gradle
@@ -47,16 +47,53 @@ p2AsMaven {
         slicingOption 'includeNonGreedy', 'false'
         slicingOption 'includeOptional', 'false'
     }
+
+    group 'calcite-eclipse-deps', {
+        repoEclipse '4.18'
+        iu 'org.eclipse.help'
+        iu 'org.eclipse.jface'
+        iu 'org.eclipse.jface.text'
+        iu 'org.eclipse.swt'
+        iu 'org.eclipse.ui'
+        feature 'org.eclipse.platform'
+        append true
+        slicingOption 'includeFeatures', 'false'
+        slicingOption 'includeNonGreedy', 'false'
+        slicingOption 'includeOptional', 'false'
+        slicingOption 'platformFilter', 'linux,gtk,x86_64'
+    }
+
+    group 'calcite-mat-deps', {
+        repo 'https://archive.eclipse.org/mat/photon/M7/update-site/'
+        iu 'org.eclipse.mat.ui'
+        append true
+        slicingOption 'includeFeatures', 'false'
+        slicingOption 'includeNonGreedy', 'false'
+        slicingOption 'includeOptional', 'false'
+    }
+
+    group 'mat-calcite-plugin', {
+        repo 'jar:https://github.com/vlsi/mat-calcite-plugin/releases/download/v1.5.0/MatCalciteRepository-1.5.0.zip!/'
+        iu 'MatCalcitePlugin'
+        append true
+        slicingOption 'includeFeatures', 'false'
+        slicingOption 'includeNonGreedy', 'false'
+        slicingOption 'includeOptional', 'false'
+    }
 }
 
 afterEvaluate {
     copy {
         from files(
+                "${buildDir}/p2asmaven/p2/mat-calcite-plugin/plugins",
+                "${buildDir}/p2asmaven/p2/calcite-eclipse-deps/plugins",
+                "${buildDir}/p2asmaven/p2/calcite-mat-deps/plugins",
                 "${buildDir}/p2asmaven/p2/eclipse-deps/plugins",
-                "${buildDir}/p2asmaven/p2/eclipse-mat/plugins")
+                "${buildDir}/p2asmaven/p2/eclipse-mat/plugins",
+                )
         into "${mat_deps_dir_path}"
         include '*.jar'
-        rename '(.+)_(.+)', '$1.jar'
+        rename '(.+)', '$1'
     }
 }
 
@@ -65,4 +102,3 @@ task clean {
         delete files("${projectDir}/workspace")
     }
 }
-

--- a/backend/heap-dump-analyzer/impl/build.gradle
+++ b/backend/heap-dump-analyzer/impl/build.gradle
@@ -18,7 +18,7 @@ jar {
     manifest {
         attributes(
                 "Bundle-SymbolicName": "org.eclipse.jifa.hda.implementation; singleton:=true",
-                "Require-Bundle": "org.eclipse.mat.api;bundle-version=\"1.12.0\",org.eclipse.mat.parser;bundle-version=\"1.12.0\",org.eclipse.osgi",
+                "Require-Bundle": "org.eclipse.mat.api,org.eclipse.mat.parser,org.eclipse.osgi,MatCalcitePlugin",
                 "Bundle-Activator": "org.eclipse.jifa.hda.impl.Activator",
                 "Import-Package":
                         "org.eclipse.mat.snapshot,org.eclipse.mat.util,org.eclipse.mat.query,org.eclipse.mat.parser.model",
@@ -34,15 +34,12 @@ dependencies {
     implementation project(':backend:common')
 
     def prefix = "${mat_deps_dir_path}/"
-    implementation files(
-            "${prefix}org.eclipse.osgi.jar",
-            "${prefix}org.eclipse.equinox.registry.jar",
-            "${prefix}org.apache.felix.scr.jar",
-            "${prefix}org.eclipse.equinox.event.jar",
-            "${prefix}org.eclipse.mat.report.jar",
-            "${prefix}org.eclipse.mat.api.jar",
-            "${prefix}org.eclipse.mat.parser.jar",
-            "${prefix}org.eclipse.mat.hprof.jar")
+    implementation fileTree(prefix) {
+        include osgi_jar
+        include "org.eclipse.mat.parser_*.jar"
+        include "org.eclipse.mat.report_*.jar"
+        include "org.eclipse.mat.api_*.jar"
+    }
 }
 
 task installJar(type: Copy, dependsOn: jar) {

--- a/backend/heap-dump-analyzer/provider/src/main/java/org/eclipse/jifa/hdp/provider/MATProvider.java
+++ b/backend/heap-dump-analyzer/provider/src/main/java/org/eclipse/jifa/hdp/provider/MATProvider.java
@@ -21,6 +21,7 @@ import org.osgi.framework.BundleException;
 import org.osgi.framework.Constants;
 import org.osgi.framework.launch.Framework;
 import org.osgi.framework.launch.FrameworkFactory;
+import org.osgi.framework.wiring.BundleRevision;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -79,14 +80,22 @@ public class MATProvider implements HeapDumpAnalyzer.Provider {
             for (File file : files) {
                 String name = file.getName();
                 // org.eclipse.osgi is the system bundle
-                if (name.endsWith(".jar") && !name.equals("org.eclipse.osgi.jar")) {
+                if (name.endsWith(".jar") && !name.startsWith("org.eclipse.osgi_")) {
                     Bundle b = framework.getBundleContext().installBundle(file.toURI().toString());
                     bundles.add(b);
                 }
             }
 
+            ArrayList validNames = new ArrayList();
+            validNames.add("org.apache.felix.scr");
+            validNames.add("org.eclipse.equinox.event");
+            validNames.add("org.eclipse.jifa.hda.implementation");
+
             for (Bundle bundle : bundles) {
-                bundle.start();
+                if (validNames.contains(bundle.getSymbolicName())) {
+                    System.out.println("starting bundle:   " + bundle);
+                    bundle.start();
+                }
             }
 
             analyzer =

--- a/backend/worker/src/main/java/org/eclipse/jifa/worker/route/heapdump/CalciteSQLRoute.java
+++ b/backend/worker/src/main/java/org/eclipse/jifa/worker/route/heapdump/CalciteSQLRoute.java
@@ -1,0 +1,35 @@
+/********************************************************************************
+ * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ********************************************************************************/
+package org.eclipse.jifa.worker.route.heapdump;
+
+import io.vertx.core.Promise;
+import org.eclipse.jifa.common.request.PagingRequest;
+import org.eclipse.jifa.hda.api.Model;
+import org.eclipse.jifa.worker.route.ParamKey;
+import org.eclipse.jifa.worker.route.RouteMeta;
+
+import static org.eclipse.jifa.worker.support.Analyzer.HEAP_DUMP_ANALYZER;
+import static org.eclipse.jifa.worker.support.Analyzer.getOrOpenAnalysisContext;
+
+class CalciteSQLRoute extends HeapBaseRoute {
+
+    @RouteMeta(path = "/sql")
+    void calciteSql(Promise<Model.CalciteSQLResult> promise, @ParamKey("file") String file,
+             @ParamKey("sql") String oql, @ParamKey(value = "sortBy", mandatory = false) String sortBy,
+             @ParamKey(value = "ascendingOrder", mandatory = false) boolean ascendingOrder,
+             PagingRequest pagingRequest) {
+        promise.complete(HEAP_DUMP_ANALYZER.getCalciteSQLResult(getOrOpenAnalysisContext(file),
+                                                        oql, sortBy, ascendingOrder,
+                                                        pagingRequest.getPage(), pagingRequest.getPageSize()));
+    }
+}

--- a/backend/worker/src/main/java/org/eclipse/jifa/worker/route/heapdump/HeapBaseRoute.java
+++ b/backend/worker/src/main/java/org/eclipse/jifa/worker/route/heapdump/HeapBaseRoute.java
@@ -37,6 +37,7 @@ public class HeapBaseRoute extends BaseRoute {
         ROUTES.add(ObjectListRoute.class);
         ROUTES.add(ClassReferenceRoute.class);
         ROUTES.add(OQLRoute.class);
+        ROUTES.add(CalciteSQLRoute.class);
         ROUTES.add(DirectByteBufferRoute.class);
         ROUTES.add(GCRootRoute.class);
         ROUTES.add(PathToGCRootsRoute.class);

--- a/backend/worker/src/test/java/org/eclipse/jifa/worker/route/HeapDumpRouteSuite.java
+++ b/backend/worker/src/test/java/org/eclipse/jifa/worker/route/HeapDumpRouteSuite.java
@@ -184,6 +184,14 @@ public class HeapDumpRouteSuite extends Base {
                         .addQueryParam("ascendingOrder", "true")
                         .addQueryParam("pageSize", "10"));
 
+        // oql
+        testGet("/sql",
+                (PreProcessor) req -> req.addQueryParam("sql", "select * from java.lang.String")
+                        .addQueryParam("page", "1")
+                        .addQueryParam("sortBy", "id")
+                        .addQueryParam("ascendingOrder", "true")
+                        .addQueryParam("pageSize", "10"));
+
         // path to gc roots
         testGet("/pathToGCRoots",
                 (PreProcessor) req -> req.addQueryParam("origin", String.valueOf(holder.id))

--- a/frontend/src/components/heapdump/HeapDump.vue
+++ b/frontend/src/components/heapdump/HeapDump.vue
@@ -177,6 +177,21 @@
                   <span slot="label"> OQL </span>
                   <div v-bind:style="{ 'height': '100%', 'width': resultDivWidth}">
                     <OQL :file="file"
+                         queryType="oql"
+                         @outgoingRefsOfObj="outgoingRefsOfObj"
+                         @incomingRefsOfObj="incomingRefsOfObj"
+                         @outgoingRefsOfClass="outgoingRefsOfClass"
+                         @incomingRefsOfClass="incomingRefsOfClass"
+                         @pathToGCRootsOfObj="pathToGCRootsOfObj"
+                         @setSelectedObjectId="setSelectedObjectId"/>
+                  </div>
+                </el-tab-pane>
+
+                <el-tab-pane name="calcitesSQL" lazy>
+                  <span slot="label"> Calcite SQL </span>
+                  <div v-bind:style="{ 'height': '100%', 'width': resultDivWidth}">
+                    <OQL :file="file"
+                         queryType="sql"
                          @outgoingRefsOfObj="outgoingRefsOfObj"
                          @incomingRefsOfObj="incomingRefsOfObj"
                          @outgoingRefsOfClass="outgoingRefsOfClass"

--- a/frontend/src/components/heapdump/OQL.vue
+++ b/frontend/src/components/heapdump/OQL.vue
@@ -42,9 +42,9 @@
 
     <div style="height: 45px; margin-top: 5px">
       <el-autocomplete
-              v-model="oql"
+              v-model="query"
               :fetch-suggestions="queryHistory"
-              placeholder="Object Query Language ..."
+              placeholder="Query ..."
               :trigger-on-focus="false"
               prefix-icon="el-icon-edit"
               @keyup.enter.native="search"
@@ -58,10 +58,17 @@
       </el-autocomplete>
     </div>
 
-    <div align="left" style="height: 25px; margin-bottom: 5px">
+    <div align="left" style="height: 25px; margin-bottom: 5px" v-if="queryType == 'oql'">
       <a href="https://help.eclipse.org/oxygen/index.jsp?topic=%2Forg.eclipse.mat.ui.help%2Freference%2Foqlsyntax.html&cp=66_4_2"
          target="_blank" style="font-size: 12px; font-weight: bold; color: #909399; text-decoration: underline">
         > Click to get detailed OQL Help documents.
+      </a>
+    </div>
+
+    <div align="left" style="height: 25px; margin-bottom: 5px" v-if="queryType == 'sql'">
+      <a href="https://github.com/vlsi/mat-calcite-plugin#sample"
+         target="_blank" style="font-size: 12px; font-weight: bold; color: #909399; text-decoration: underline">
+        > Click to get detailed Calcite SQL Help.
       </a>
     </div>
 
@@ -103,7 +110,7 @@
 
             <span v-if="scope.row.isSummaryItem">
               <img :src="ICONS.misc.sumIcon" v-if="treeResult.length >= totalSize"/>
-              <img :src="ICONS.misc.sumPlusIcon" @dblclick="fetchResult(scope.row.oql)" style="cursor: pointer" v-else/>
+              <img :src="ICONS.misc.sumPlusIcon" @dblclick="fetchResult(scope.row.query)" style="cursor: pointer" v-else/>
               {{ treeResult.length }} <strong> / </strong> {{totalSize}}
             </span>
           </template>
@@ -136,7 +143,7 @@
 
             <span v-if="scope.row.isSummaryItem && index === 0">
             <img :src="ICONS.misc.sumIcon" v-if="tableResult.length >= totalSize"/>
-            <img :src="ICONS.misc.sumPlusIcon" @dblclick="fetchResult(scope.row.oql)" style="cursor: pointer" v-else/>
+            <img :src="ICONS.misc.sumPlusIcon" @dblclick="fetchResult(scope.row.query)" style="cursor: pointer" v-else/>
             {{ tableResult.length }} <strong> / </strong> {{totalSize}}
           </span>
           </template>
@@ -161,13 +168,13 @@
 
   let rowKey = 1
 
-  // oql result type
+  // query result type
   const TREE = 1
   const TABLE = 2
   const TEXT = 3
 
   export default {
-    props: ['file'],
+    props: ['file', 'queryType'],
     data() {
       return {
         ICONS,
@@ -175,7 +182,7 @@
         headerCellStyle: {padding: 0, 'font-size': '12px', 'font-weight': 'normal'},
         searching: false,
         loading: false,
-        oql: '',
+        query: '',
         nextPage: 1,
         pageSize: 25,
         totalSize: 0,
@@ -197,7 +204,7 @@
         isTableResult: false,
         isTextResult: false,
 
-        historyOQLs: [],
+        historyQueries: [],
         treeSortBy:'retainedHeap',
         treeAscendingOrder:true,
       }
@@ -210,23 +217,24 @@
       },
 
       sortTree(val){
-        if (this.oql) {
+        if (this.query) {
           this.treeSortBy = val.prop;
           this.treeAscendingOrder = val.order === 'ascending';
           this.searching = true
           this.clear()
-          this.fetchResult(this.oql)
+          this.fetchResult(this.query)
         }
       },
 
-      fetchResult(oql) {
-        if (!oql || oql.length === 0) {
+      fetchResult(query) {
+        if (!query || query.length === 0) {
           return
         }
         this.loading = true
-        axios.get(heapDumpService(this.file, 'oql'), {
+        axios.get(heapDumpService(this.file, this.queryType), {
           params: {
-            oql: oql,
+            oql: this.queryType == 'oql' ? query : undefined,
+            sql: this.queryType == 'sql' ? query : undefined,
             page: this.nextPage,
             pageSize: this.pageSize,
             sortBy: this.treeSortBy,
@@ -235,7 +243,7 @@
         }).then(resp => {
           this.adjustDataByResultType(resp.data.type)
           if (this.isTreeResult) {
-            this.putHistory(oql)
+            this.putHistory(query)
             this.totalSize = resp.data.pv.totalSize
             let data = resp.data.pv.data
             data.forEach(d => {
@@ -254,12 +262,12 @@
             })
             this.treeTableData = this.treeResult.concat({
               rowKey: rowKey++,
-              oql: oql,
+              query: query,
               isSummaryItem: true
             })
             this.nextPage++
           } else if (this.isTableResult) {
-            this.putHistory(oql)
+            this.putHistory(query)
             this.totalSize = resp.data.pv.totalSize
             this.tableResultColumns = resp.data.columns
             let data = resp.data.pv.data
@@ -274,7 +282,7 @@
             })
             this.tableTableData = this.tableResult.concat({
               rowKey: rowKey++,
-              oql: oql,
+              query: query,
               isSummaryItem: true
             })
             this.nextPage++
@@ -357,29 +365,29 @@
       },
 
       search() {
-        if (this.oql) {
+        if (this.query) {
           this.searching = true
           this.clear()
-          this.fetchResult(this.oql)
+          this.fetchResult(this.query)
         }
       },
 
-      putHistory(oql) {
-        let target = oql.trim()
-        for (let i = 0; i < this.historyOQLs.length; i++) {
-          if (this.historyOQLs[i].value === target) {
+      putHistory(query) {
+        let target = query.trim()
+        for (let i = 0; i < this.historyQueries.length; i++) {
+          if (this.historyQueries[i].value === target) {
             return
           }
         }
 
-        this.historyOQLs.push({value: target})
-        if (this.historyOQLs.length > 11) {
-          this.historyOQLs.shift()
+        this.historyQueries.push({value: target})
+        if (this.historyQueries.length > 11) {
+          this.historyQueries.shift()
         }
       },
 
       queryHistory(queryString, cb) {
-        let history = this.historyOQLs;
+        let history = this.historyQueries;
         let results = queryString ? history.filter(this.createFilter(queryString)) : history;
         cb(results);
       },


### PR DESCRIPTION
This introduces a new Calcite SQL-based query engine which allows the user to run SQL-like queries against the heapdump.

[Plugin home](https://github.com/vlsi/mat-calcite-plugin).

[Sample query](https://github.com/vlsi/mat-calcite-plugin#sample).

In our experience, different queries may be simpler to write and faster to execute with Calcite SQL engine.

For example, this SQL query collects a string field of an object `name`, and counts all instances of the object with a common name:
```
select m.name metric_name, count(*) metric_count
from "com.netflix.spectator.api.DefaultId" m
group by m.name
order by metric_count desc
```

![image](https://user-images.githubusercontent.com/3196528/131536418-55a884f1-5379-4dcc-96e3-297483bee09a.png)
