### PR TITLE
support prepared oql and calcite queries

### DIFF
--- a/frontend/src/components/heapdump/HeapDump.vue
+++ b/frontend/src/components/heapdump/HeapDump.vue
@@ -177,6 +177,7 @@
                   <span slot="label"> Query (OQL/Calcite) </span>
                   <div v-bind:style="{ 'height': '100%', 'width': resultDivWidth}">
                     <Query :file="file"
+                         queryType="oql"
                          @outgoingRefsOfObj="outgoingRefsOfObj"
                          @incomingRefsOfObj="incomingRefsOfObj"
                          @outgoingRefsOfClass="outgoingRefsOfClass"

--- a/frontend/src/components/heapdump/Query.vue
+++ b/frontend/src/components/heapdump/Query.vue
@@ -48,6 +48,7 @@
       <el-autocomplete
               v-model="query"
               :fetch-suggestions="queryHistory"
+              :disabled="disabledInput"
               placeholder="Query ..."
               :trigger-on-focus="false"
               prefix-icon="el-icon-edit"
@@ -178,7 +179,7 @@
   const TEXT = 3
 
   export default {
-    props: ['file'],
+    props: ['file', 'queryType', 'preparedQuery'],
     data() {
       return {
         ICONS,
@@ -187,7 +188,6 @@
         searching: false,
         loading: false,
         query: '',
-        queryType: 'oql',
         nextPage: 1,
         pageSize: 25,
         totalSize: 0,
@@ -212,6 +212,8 @@
         historyQueries: [],
         treeSortBy:'retainedHeap',
         treeAscendingOrder:true,
+
+        disabledInput: false,
       }
     },
     methods: {
@@ -402,6 +404,16 @@
           return (history.value.toLowerCase().indexOf(queryString.toLowerCase().trim()) === 0);
         };
       },
+    },
+
+    created() {
+      if (this.preparedQuery) {
+        this.query = this.preparedQuery
+        this.disabledInput = true
+        this.search()
+      } else {
+        this.disabledInput = false
+      }
     }
   }
 </script>


### PR DESCRIPTION
Support views setting up a new menu-item tab based on an oql or calcite sql query, for example (query over a specific component). Pass in a `queryType` and a `preparedQuery` and it will be executed immediately in `created()` callback. The ability to edit the query is disabled but you can copy the text.

```
<el-tab-pane name="nflxMetrics" lazy>
  <span slot="label"> Atlas metrics </span>
  <div v-bind:style="{ 'height': '100%', 'width': resultDivWidth}">
    <Query :file="file"
         queryType="sql"
         @outgoingRefsOfObj="outgoingRefsOfObj"
         @incomingRefsOfObj="incomingRefsOfObj"
         @outgoingRefsOfClass="outgoingRefsOfClass"
         @incomingRefsOfClass="incomingRefsOfClass"
         @pathToGCRootsOfObj="pathToGCRootsOfObj"
         @setSelectedObjectId="setSelectedObjectId"
         preparedQuery='select m.name metric_name, count(*) metric_count from "com.netflix.spectator.api.DefaultId" m group by m.name order by metric_count desc' />
  </div>
</el-tab-pane>
```

![image](https://user-images.githubusercontent.com/3196528/131885126-57a04a00-d896-4453-8a24-986b8a6bc3c2.png)
