### PR TITLE
feat: support downloading original file in full cluster mode

### DIFF
--- a/backend/common/src/main/java/org/eclipse/jifa/common/Constant.java
+++ b/backend/common/src/main/java/org/eclipse/jifa/common/Constant.java
@@ -14,7 +14,14 @@ package org.eclipse.jifa.common;
 
 public interface Constant {
     String HEADER_CONTENT_TYPE_KEY = "Content-Type";
+    String HEADER_CONTENT_LENGTH_KEY = "Content-Length";
+    String HEADER_CONTENT_DISPOSITION = "Content-Disposition";
+    String HEADER_AUTHORIZATION = "authorization";
     String CONTENT_TYPE_JSON_FORM = "application/json; charset=UTF-8";
+    String CONTENT_TYPE_FILE_FORM = "application/octet-stream";
+
+    String COOKIE_AUTHORIZATION = "grace-authorization";
+    String HEADER_AUTHORIZATION_PREFIX = "Bearer ";
 
     int HTTP_GET_OK_STATUS_CODE = 200;
     int HTTP_POST_CREATED_STATUS_CODE = 201;

--- a/backend/common/src/main/java/org/eclipse/jifa/common/ErrorCode.java
+++ b/backend/common/src/main/java/org/eclipse/jifa/common/ErrorCode.java
@@ -69,6 +69,8 @@ public enum ErrorCode {
 
     FILE_IS_BEING_DELETING,
 
+    FILE_TOO_BIG,
+
     RELEASE_PENDING_JOB;
 
     public boolean isFatal() {

--- a/backend/master/src/main/java/org/eclipse/jifa/master/Constant.java
+++ b/backend/master/src/main/java/org/eclipse/jifa/master/Constant.java
@@ -73,6 +73,7 @@ public interface Constant extends org.eclipse.jifa.common.Constant {
     String UPLOAD_TO_OSS = "/file/uploadToOSS";
     String UPLOAD_TO_OSS_PROGRESS = "/file/uploadToOSSProgress";
 
+    String DOWNLOAD = "/file/download";
     /**
      * JOB URL
      */
@@ -103,6 +104,8 @@ public interface Constant extends org.eclipse.jifa.common.Constant {
     String PASSWORD = "password";
     String PORT = "port";
     String SYSTEM_DISK_USAGE = "/system/diskUsage";
+
+    long MAX_SIZE_FOR_DOWNLOAD = 512 * 1024 * 1024; // 512MB
 
     /**
      * DEV

--- a/backend/master/src/main/java/org/eclipse/jifa/master/http/FileRoute.java
+++ b/backend/master/src/main/java/org/eclipse/jifa/master/http/FileRoute.java
@@ -17,9 +17,12 @@ import io.reactivex.Single;
 import io.vertx.core.json.JsonObject;
 import io.vertx.reactivex.core.MultiMap;
 import io.vertx.reactivex.core.Vertx;
+import io.vertx.reactivex.core.buffer.Buffer;
 import io.vertx.reactivex.core.http.HttpServerRequest;
 import io.vertx.reactivex.ext.web.Router;
 import io.vertx.reactivex.ext.web.RoutingContext;
+import io.vertx.reactivex.ext.web.client.HttpRequest;
+import io.vertx.reactivex.ext.web.codec.BodyCodec;
 import org.apache.commons.lang.StringUtils;
 import org.eclipse.jifa.common.ErrorCode;
 import org.eclipse.jifa.common.JifaException;
@@ -111,6 +114,8 @@ class FileRoute extends BaseRoute implements Constant {
 
         apiRouter.post().path(UPLOAD_TO_OSS).handler(this::uploadToOSS);
         apiRouter.get().path(UPLOAD_TO_OSS_PROGRESS).handler(this::uploadToOSSProgress);
+
+        apiRouter.get().path(DOWNLOAD).handler(this::download);
     }
 
     private void files(RoutingContext context) {
@@ -312,5 +317,26 @@ class FileRoute extends BaseRoute implements Constant {
             progress.setTransferredSize(file.getSize());
         }
         return progress;
+    }
+
+    private void download(RoutingContext context) {
+        String name = context.request().getParam("name");
+        User user = context.get(USER_INFO_KEY);
+        fileService.rxFile(name)
+                .doOnSuccess(file -> ASSERT.isTrue(file.found(), ErrorCode.FILE_DOES_NOT_EXIST))
+                .doOnSuccess(file -> checkPermission(user, file))
+                .doOnSuccess(file -> ASSERT.isTrue(file.getSize() < MAX_SIZE_FOR_DOWNLOAD, ErrorCode.FILE_TOO_BIG))
+                .flatMap(file -> {
+                    context.response()
+                            .putHeader(HEADER_CONTENT_LENGTH_KEY, String.valueOf(file.getSize()))
+                            .putHeader(HEADER_CONTENT_DISPOSITION, "attachment;filename=" + file.getName())
+                            .putHeader(HEADER_CONTENT_TYPE_KEY, CONTENT_TYPE_FILE_FORM);
+                    HttpRequest<Buffer> workerRequest = WorkerClient.request(context.request().method(), file.getHostIP(), context.request().uri());
+                    workerRequest.as(BodyCodec.pipe(context.response()));
+                    return WorkerClient.send(workerRequest, null);
+                })
+                .subscribe(resp -> context.response().end(),
+                        t -> HTTPRespGuarder.fail(context, t));
+
     }
 }

--- a/backend/master/src/main/java/org/eclipse/jifa/master/support/WorkerClient.java
+++ b/backend/master/src/main/java/org/eclipse/jifa/master/support/WorkerClient.java
@@ -96,6 +96,13 @@ public class WorkerClient {
         return request.basicAuthentication(USERNAME, PASSWORD).rxSend();
     }
 
+    public static Single<HttpResponse<Buffer>> send(HttpRequest<Buffer> request, MultiMap params) {
+        if (params != null) {
+            request.queryParams().addAll(params);
+        }
+        return request.basicAuthentication(USERNAME, PASSWORD).rxSend();
+    }
+
     private static HttpRequest<Buffer> request(HttpMethod method, String hostIP, int port, String uri) {
         if (method == HttpMethod.GET) {
             return client.get(port, hostIP, uri);
@@ -106,5 +113,10 @@ public class WorkerClient {
         LOGGER.error("Unsupported worker http request method {}", method);
         throw new IllegalArgumentException();
     }
+
+    public static HttpRequest<Buffer> request(HttpMethod method, String hostIP, String uri) {
+        return request(method, hostIP, PORT, uri);
+    }
+
 }
 

--- a/backend/worker/src/main/java/org/eclipse/jifa/worker/route/FileRoute.java
+++ b/backend/worker/src/main/java/org/eclipse/jifa/worker/route/FileRoute.java
@@ -42,7 +42,7 @@ import java.net.URL;
 import java.util.List;
 import java.util.Set;
 
-import static org.eclipse.jifa.common.Constant.EMPTY_STRING;
+import static org.eclipse.jifa.common.Constant.*;
 import static org.eclipse.jifa.common.util.Assertion.ASSERT;
 
 class FileRoute extends BaseRoute {
@@ -237,11 +237,12 @@ class FileRoute extends BaseRoute {
         HTTPRespGuarder.ok(context);
     }
 
-    @RouteMeta(path = "/file/download/:fileType/:filename", contentType = {} /* keep content-type empty */)
-    void download(RoutingContext context, @ParamKey("fileType") FileType fileType, @ParamKey("filename") String name) {
+    @RouteMeta(path = "/file/download", contentType = {CONTENT_TYPE_FILE_FORM})
+    void download(RoutingContext context, @ParamKey("type") FileType fileType, @ParamKey("name") String name) {
         File file = new File(FileSupport.filePath(fileType, name));
         ASSERT.isTrue(file.exists(), "File doesn't exist!");
         HttpServerResponse response = context.response();
+        response.putHeader(HEADER_CONTENT_DISPOSITION, "attachment;filename=" + file.getName());
         response.sendFile(file.getAbsolutePath(), event -> {
             if (!response.ended()) {
                 response.end();

--- a/frontend/src/components/finder.vue
+++ b/frontend/src/components/finder.vue
@@ -57,8 +57,7 @@
                   </p>
                 </el-col>
 
-                <el-col :span="8" align="right">
-
+                <el-col :span="11" align="right" class="icons-col">
                   <el-tooltip class="item" effect="light" :content="$t('jifa.tip.copyName')" placement="top-start">
                     <span>
                       <el-link icon="el-icon-document-copy" v-clipboard:copy="file(row, col).name"
@@ -84,14 +83,18 @@
                     </span>
                   </el-tooltip>
 
-
-                  <span v-if="downloadable(file(row,col))">
-                    <el-divider direction="vertical"></el-divider>
-                    <el-link icon="el-icon-download" :underline="false"
-                             :href="service('/file/download/' + currentMenuItem + '/' + file(row, col).name)"
-                             target="_blank"/>
-                  </span>
-
+                  <el-tooltip class="item" effect="light" :content="$t('jifa.tip.downloadFile')" placement="top-start"
+                              v-if="transferIsSuccess(file(row,col))">
+                    <span>
+                      <el-divider direction="vertical"></el-divider>
+                      <el-link icon="el-icon-download" :underline="false"
+                               :disabled="fileTooBigToDownload(file(row, col))"
+                               target="_blank"
+                               download
+                               :href="`/jifa-api/file/download?name=${file(row,col).name}&type=${currentMenuItem}`"
+                      />
+                    </span>
+                  </el-tooltip>
 
                   <el-tooltip class="item" effect="light" :content="$t('jifa.tip.deleteFile')" placement="top-start">
                     <span v-if="canDelete(file(row,col))">
@@ -254,8 +257,9 @@
         })
       },
 
-      downloadable(file) {
-        return file.downloadble && this.transferIsSuccess(file)
+      fileTooBigToDownload(file) {
+        // don't restrict size in worker only mode
+        return file.size > 512 * 1024 * 1024 && !this.$jifa.workerOnly
       },
 
       transferIsSuccess(file) {
@@ -357,3 +361,11 @@
     }
   }
 </script>
+
+<style scoped>
+
+.icons-col .el-divider {
+  margin-left: 4px;
+  margin-right: 4px;
+}
+</style>

--- a/frontend/src/components/menu/AnalysisResultMenu.vue
+++ b/frontend/src/components/menu/AnalysisResultMenu.vue
@@ -20,6 +20,12 @@
       <i class="el-icon-s-release" style="margin-right: 3px"/> {{$t("jifa.release")}}
     </b-nav-item>
 
+    <b-nav-item :href="`/jifa-api/file/download?name=${file}&type=${type}`"
+                download
+                v-if="$jifa.fileManagement && showDownloadOpt">
+      <i class="el-icon-download" style="margin-right: 3px"/> {{$t("jifa.download")}}
+    </b-nav-item>
+
     <b-nav-item-dropdown right v-if="analysisState === 'SUCCESS' && type === 'HEAP_DUMP'">
       <template v-slot:button-content>
         <i class="el-icon-setting" style="margin-right: 3px"/> {{$t("jifa.setting")}}
@@ -53,6 +59,7 @@
     data(){
       return {
         showUnlockOpt: false,
+        showDownloadOpt: false,
       }
     },
 
@@ -126,6 +133,7 @@
     mounted() {
       // workerOnly mode does not need this
       if (this.$jifa.workerOnly) {
+        this.showDownloadOpt = true;
         return;
       }
 
@@ -136,8 +144,12 @@
       }).then(resp => {
         let data = resp.data;
 
+        // File too big to download?
+        const showDownloadOpt = data.size <= 512 * 1024 * 1024
+
         // Already shared?
         if (data.shared) {
+          this.showDownloadOpt = showDownloadOpt;
           return;
         }
 
@@ -155,6 +167,7 @@
 
           // Finally...
           this.showUnlockOpt = true;
+          this.showDownloadOpt = showDownloadOpt;
         });
       })
     }

--- a/frontend/src/i18n/cn.js
+++ b/frontend/src/i18n/cn.js
@@ -52,6 +52,7 @@ exports.default = {
     analyze: '分析',
     reanalyze: '重新分析',
     release: '释放',
+    download: '下载原文件',
     edit: '编辑',
     delete: '删除',
     loading: '加载中',
@@ -60,6 +61,7 @@ exports.default = {
     deleteSuccessPrompt: '删除成功！',
     deleteFailedPrompt: '删除失败！',
     deleteCanceled: '已取消删除',
+    downloadBegin: '文件开始下载，请耐心等待',
     returnValue: '确定离开吗?',
     gotoParseFile: '即将解析文件',
 
@@ -84,6 +86,7 @@ exports.default = {
       uploadToOSS: '上传文件到OSS',
       setShare: '设置文件共享',
       deleteFile: '删除文件',
+      downloadFile: '本地下载文件。最大支持512MB',
     },
 
     heap: {

--- a/frontend/src/i18n/cn.js
+++ b/frontend/src/i18n/cn.js
@@ -86,7 +86,7 @@ exports.default = {
       uploadToOSS: '上传文件到OSS',
       setShare: '设置文件共享',
       deleteFile: '删除文件',
-      downloadFile: '本地下载文件。最大支持512MB',
+      downloadFile: '本地下载文件，最大支持512MB',
     },
 
     heap: {

--- a/frontend/src/i18n/en.js
+++ b/frontend/src/i18n/en.js
@@ -51,7 +51,7 @@ exports.default = {
     progress: 'Progress',
     analyze: 'analyze',
     reanalyze: 'Reanalyze',
-    release: 'Release',
+    download: 'Download File',
     edit: 'edit',
     delete: 'Delete',
     loading: 'Loading',
@@ -60,6 +60,7 @@ exports.default = {
     deleteSuccessPrompt: 'Delete success!',
     deleteFailedPrompt: 'Delete failed!',
     deleteCanceled: 'Delete operation is canceled',
+    downloadBegin: 'Downloading has began. Please wait',
     returnValue: 'Are you sure to leave?',
     gotoParseFile: 'Will go to parse file',
 
@@ -86,6 +87,7 @@ exports.default = {
       uploadToOSS: 'Upload file to OSS',
       setShare: 'Set file as shared',
       deleteFile: 'Delete file permanently',
+      downloadFile: 'Download file. Max supported size is 512MB',
     },
 
     heap: {


### PR DESCRIPTION
Sometimes user want to read original file that was uploaded to to JIFA for some reason. This patch allows user to download the file, with size limit 512MB in master-worker mode and no limit in worker-only mode.