### PR TITLE
Bump log4j2 to 2.17.1

### DIFF
--- a/backend/common/common.gradle
+++ b/backend/common/common.gradle
@@ -15,7 +15,7 @@ plugins {
 }
 
 dependencies {
-    api "org.apache.logging.log4j:log4j-slf4j-impl:2.16.0"
+    api "org.apache.logging.log4j:log4j-slf4j-impl:2.17.1"
 
     api 'commons-lang:commons-lang:2.6'
 


### PR DESCRIPTION
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44832