### PR TITLE
fix: add authorization cookie path

### DIFF
--- a/backend/master/src/main/java/org/eclipse/jifa/master/http/UserRoute.java
+++ b/backend/master/src/main/java/org/eclipse/jifa/master/http/UserRoute.java
@@ -102,6 +102,7 @@ class UserRoute implements Constant {
             authHeader = authHeader.substring(HEADER_AUTHORIZATION_PREFIX.length());
             if (authCookie == null || !authHeader.equals(authCookie.getValue())) {
                 Cookie cookie = Cookie.cookie(COOKIE_AUTHORIZATION, authHeader);
+                cookie.setPath("/");
                 context.addCookie(cookie);
             }
         }


### PR DESCRIPTION
Fix the problem that sometimes users can not download file if they don't enter jifa from the homepage. This is because the cookie is not on the path.