### PR TITLE
[Heap Dump]: bump mat deps from 1.12.0 to 1.13.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,13 @@ The frontend of Jifa uses Vue as the main framework.
 ### Build
 
 - Prerequisites
-  - JDK 11 or 17, and make sure $JAVA_HOME is set properly
+  - JDK 8, and make sure $JAVA_HOME is set properly
+
+    ```
+    Jifa uses the plugin 'com.diffplug.p2.asmaven' to get MAT's dependencies.
+    Thisplugin can only run on JRE 8 now, so we need to set $JAVA_HOME to JDK8.
+    While other modules depend on JDK11+, Gradle handles this for us correctly.
+    ```
   - npm
 
 - Build All

--- a/backend/backend.gradle
+++ b/backend/backend.gradle
@@ -23,16 +23,26 @@ def HEAP_DUMP_ANALYZER_HOOK = 'heap-dump-analyzer:hook'
 def GC_LOG_ANALYZER = 'gc-log-analyzer'
 def THREAD_DUMP_ANALYZER = 'thread-dump-analyzer'
 
-[COMMON, WORKER, MASTER, HEAP_DUMP_ANALYZER_API, HEAP_DUMP_ANALYZER_IMPL, HEAP_DUMP_ANALYZER_PROVIDER, GC_LOG_ANALYZER, THREAD_DUMP_ANALYZER].each {
+[COMMON, WORKER, MASTER, HEAP_DUMP_ANALYZER_API, HEAP_DUMP_ANALYZER_IMPL, HEAP_DUMP_ANALYZER_PROVIDER, HEAP_DUMP_ANALYZER_HOOK, GC_LOG_ANALYZER, THREAD_DUMP_ANALYZER].each {
     name ->
         project("$name") {
             apply plugin: 'java'
             apply plugin: 'jacoco'
+            java {
+                toolchain {
+                    languageVersion = JavaLanguageVersion.of(11)
+                }
+            }
             compileJava {
-                options.encoding = "UTF-8"
                 targetCompatibility = JavaVersion.VERSION_11
                 sourceCompatibility = JavaVersion.VERSION_11
+                options.encoding = "UTF-8"
                 options.compilerArgs << "-Xlint:deprecation"
+            }
+            tasks.withType(JavaCompile).configureEach {
+                javaCompiler = javaToolchains.compilerFor {
+                    languageVersion = JavaLanguageVersion.of(11)
+                }
             }
             test {
                 useJUnit()
@@ -75,7 +85,7 @@ def deps_dir_path = project(HEAP_DUMP_ANALYZER_ECLIPSE_MAT_DEPS).projectDir.pare
             ext {
                 mat_deps_dir_name = deps_dir_name
                 mat_deps_dir_path = deps_dir_path
-                osgi_jar = "org.eclipse.osgi_3.16.100.v20201030-1916.jar"
+                osgi_jar = "org.eclipse.osgi_3.17.100.v20211104-1730.jar"
             }
         }
 }

--- a/backend/heap-dump-analyzer/eclipse-mat-deps/eclipse-mat-deps.gradle
+++ b/backend/heap-dump-analyzer/eclipse-mat-deps/eclipse-mat-deps.gradle
@@ -12,12 +12,12 @@
  ********************************************************************************/
 
 plugins {
-    id 'com.diffplug.p2.asmaven' version '3.27.0'
+    id 'com.diffplug.p2.asmaven' version '3.37.1'
 }
 
 p2AsMaven {
     group 'eclipse-deps', {
-        repoEclipse '4.18'
+        repoEclipse '4.22'
         iu 'com.ibm.icu'
         iu 'org.apache.felix.scr'
         iu 'org.eclipse.core.commands'
@@ -37,7 +37,7 @@ p2AsMaven {
     }
 
     group 'eclipse-mat', {
-        repo 'http://download.eclipse.org/mat/1.12.0/update-site/'
+        repo 'http://download.eclipse.org/mat/1.13.0/update-site/'
         iu 'org.eclipse.mat.api'
         iu 'org.eclipse.mat.hprof'
         iu 'org.eclipse.mat.parser'
@@ -49,7 +49,7 @@ p2AsMaven {
     }
 
     group 'calcite-eclipse-deps', {
-        repoEclipse '4.18'
+        repoEclipse '4.22'
         iu 'org.eclipse.help'
         iu 'org.eclipse.jface'
         iu 'org.eclipse.jface.text'
@@ -82,6 +82,7 @@ p2AsMaven {
         slicingOption 'includeOptional', 'false'
     }
 }
+
 
 afterEvaluate {
     copy {


### PR DESCRIPTION
Need to upgrade the plugin 'com.diffplug.p2.asmaven', but this plugin requires JDK8...
See:
https://github.com/diffplug/goomph/blob/main/CHANGES.md#3291---2021-04-09