### PR TITLE
fix: import echarts

### DIFF
--- a/frontend/src/components/gclog/TimeLineChart.vue
+++ b/frontend/src/components/gclog/TimeLineChart.vue
@@ -22,7 +22,7 @@
 /* eslint-disable */
 import axios from "axios";
 import i18n from "@/i18n/i18n-setup";
-import echarts from 'echarts';
+import * as echarts from 'echarts';
 import {gclogService} from "@/util"
 
 export default {


### PR DESCRIPTION
Fix the problem of bumping echarts from ^4.6.0 to ^5.3.3 