### PR TITLE
fix: should list all instances of corresponding class when lookup inbound or outbound refs of histogram record (partially fixed)

### DIFF
--- a/backend/heap-dump-analyzer/api/src/main/java/org/eclipse/jifa/hda/api/HeapDumpAnalyzer.java
+++ b/backend/heap-dump-analyzer/api/src/main/java/org/eclipse/jifa/hda/api/HeapDumpAnalyzer.java
@@ -116,7 +116,9 @@ public interface HeapDumpAnalyzer {
 
     PageView<Histogram.Item> getHistogram(Histogram.Grouping groupingBy, int[] ids,
                                           String sortBy, boolean ascendingOrder,
-                                          String searchText, SearchType searchType, int page, int pageSize);
+                                         String searchText, SearchType searchType, int page, int pageSize);
+
+    PageView<JavaObject> getHistogramObjects(int classId, int page, int pageSize);
 
     PageView<Histogram.Item> getChildrenOfHistogram(Histogram.Grouping groupBy, int[] ids,
                                                     String sortBy, boolean ascendingOrder, int parentObjectId,

--- a/backend/worker/src/main/java/org/eclipse/jifa/worker/route/heapdump/HistogramRoute.java
+++ b/backend/worker/src/main/java/org/eclipse/jifa/worker/route/heapdump/HistogramRoute.java
@@ -50,4 +50,11 @@ class HistogramRoute extends HeapBaseRoute {
                                                                  pagingRequest.getPage(), pagingRequest.getPageSize()));
     }
 
+    @RouteMeta(path = "/histogram/objects")
+    void objects(Promise<PageView<Model.JavaObject>> promise, @ParamKey("file") String file,
+                   @ParamKey("classId") int classId, PagingRequest pagingRequest) {
+        promise.complete(analyzerOf(file).getHistogramObjects(classId,
+                                                              pagingRequest.getPage(),
+                                                              pagingRequest.getPageSize()));
+    }
 }

--- a/frontend/src/components/heapdump/HeapDump.vue
+++ b/frontend/src/components/heapdump/HeapDump.vue
@@ -155,6 +155,8 @@
                     <histogram :file="file" :generationInfoAvailable="generationInfoAvailable"
                                @outgoingRefsOfObj="outgoingRefsOfObj"
                                @incomingRefsOfObj="incomingRefsOfObj"
+                               @outgoingRefsOfHistogramObjs="outgoingRefsOfHistogramObj"
+                               @incomingRefsOfHistogramObjs="incomingRefsOfHistogramObj"
                                @outgoingRefsOfClass="outgoingRefsOfClass"
                                @incomingRefsOfClass="incomingRefsOfClass"
                                @pathToGCRootsOfObj="pathToGCRootsOfObj"
@@ -398,6 +400,16 @@ export default {
 
       incomingRefsOfObj(id, label) {
         this.$refs['dynamicResultSlot'].incomingRefsOfObj(id, label);
+        this.enableShowDynamicResultSlot();
+      },
+
+      outgoingRefsOfHistogramObj(id, label) {
+        this.$refs['dynamicResultSlot'].outgoingRefsOfHistogramObjs(id, label);
+        this.enableShowDynamicResultSlot();
+      },
+
+      incomingRefsOfHistogramObj(id, label) {
+        this.$refs['dynamicResultSlot'].incomingRefsOfHistogramObjs(id, label);
         this.enableShowDynamicResultSlot();
       },
 

--- a/frontend/src/components/heapdump/Histogram.vue
+++ b/frontend/src/components/heapdump/Histogram.vue
@@ -47,11 +47,13 @@
     <v-contextmenu ref="contextmenu">
       <v-contextmenu-submenu :title="$t('jifa.heap.ref.object.label')">
         <v-contextmenu-item
-                @click="$emit('outgoingRefsOfObj', contextMenuTargetObjectId, contextMenuTargetObjectLabel)">
+                @click="groupingBy === 'by_class' ? $emit('outgoingRefsOfHistogramObjs', contextMenuTargetObjectId, contextMenuTargetObjectLabel)
+                                                  : $emit('outgoingRefsOfObj', contextMenuTargetObjectId, contextMenuTargetObjectLabel)">
           {{$t('jifa.heap.ref.object.outgoing')}}
         </v-contextmenu-item>
         <v-contextmenu-item
-                @click="$emit('incomingRefsOfObj', contextMenuTargetObjectId, contextMenuTargetObjectLabel)">
+                @click="groupingBy === 'by_class' ? $emit('incomingRefsOfHistogramObjs', contextMenuTargetObjectId, contextMenuTargetObjectLabel)
+                                                  : $emit('incomingRefsOfObj', contextMenuTargetObjectId, contextMenuTargetObjectLabel)">
           {{$t('jifa.heap.ref.object.incoming')}}
         </v-contextmenu-item>
       </v-contextmenu-submenu>


### PR DESCRIPTION
this patch only fixes the problem when group_by = by_class