### PR TITLE
Added iamrole access support for accessing aws s3

### DIFF
--- a/backend/worker/src/main/java/org/eclipse/jifa/worker/support/FileSupport.java
+++ b/backend/worker/src/main/java/org/eclipse/jifa/worker/support/FileSupport.java
@@ -26,6 +26,13 @@ import com.amazonaws.regions.Regions;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.amazonaws.services.s3.model.GetObjectRequest;
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.SdkClientException;
+import com.amazonaws.auth.*;
+import com.amazonaws.auth.profile.ProfileCredentialsProvider;
+import com.amazonaws.services.s3.model.ResponseHeaderOverrides;
+import com.amazonaws.services.s3.model.S3Object;
+
 
 import io.vertx.core.Promise;
 import net.schmizz.sshj.SSHClient;
@@ -471,6 +478,7 @@ public class FileSupport {
             clientConfig.setProtocol(Protocol.HTTPS);
             s3Client = AmazonS3ClientBuilder.standard()
                                             .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                                            .withCredentials(new InstanceProfileCredentialsProvider(false))
                                             .withClientConfiguration(clientConfig)
                                             .withRegion(region)
                                             .withPathStyleAccessEnabled(true)

--- a/backend/worker/src/main/java/org/eclipse/jifa/worker/support/FileSupport.java
+++ b/backend/worker/src/main/java/org/eclipse/jifa/worker/support/FileSupport.java
@@ -460,7 +460,7 @@ public class FileSupport {
         }
     }
 
-    public static void transferByS3(String endpoint, String accessKey, String secretKey, String bucketName,
+    public static void transferByS3(String region, String accessKey, String secretKey, String bucketName,
                                     String objectName, FileType fileType, String fileName,
                                     TransferListener transferProgressListener,
                                     Promise<TransferringFile> promise) {
@@ -472,7 +472,7 @@ public class FileSupport {
             s3Client = AmazonS3ClientBuilder.standard()
                                             .withCredentials(new AWSStaticCredentialsProvider(credentials))
                                             .withClientConfiguration(clientConfig)
-                                            .withRegion("us-east-1")
+                                            .withRegion(region)
                                             .withPathStyleAccessEnabled(true)
                                             .build();
 

--- a/backend/worker/src/main/java/org/eclipse/jifa/worker/support/FileSupport.java
+++ b/backend/worker/src/main/java/org/eclipse/jifa/worker/support/FileSupport.java
@@ -472,8 +472,7 @@ public class FileSupport {
             s3Client = AmazonS3ClientBuilder.standard()
                                             .withCredentials(new AWSStaticCredentialsProvider(credentials))
                                             .withClientConfiguration(clientConfig)
-                                            .withEndpointConfiguration(
-                                                new EndpointConfiguration(endpoint, Regions.DEFAULT_REGION.getName()))
+                                            .withRegion("us-east-1")
                                             .withPathStyleAccessEnabled(true)
                                             .build();
 

--- a/frontend/src/components/transferFile.vue
+++ b/frontend/src/components/transferFile.vue
@@ -144,7 +144,7 @@
           </el-form-item>
         </el-form>
       </el-tab-pane>
-      
+
       <el-tab-pane label="O S S" name="oss">
         <el-form ref="ossForm" :model="oss" :rules="ossRules" label-width="150px" size="medium" label-position="right"
                  style="margin-top: 10px" status-icon :show-message=false>
@@ -179,12 +179,12 @@
       <el-tab-pane label="S3" name="s3">
         <el-form ref="s3Form" :model="s3" :rules="s3Rules" label-width="150px" size="medium" label-position="right"
                  style="margin-top: 10px" status-icon :show-message=false>
-          <el-form-item label="Endpoint" prop="endpoint">
-            <el-input v-model="s3.endpoint" placeholder="Endpoint" style="width: 80%" clearable></el-input>
+          <el-form-item label="Region" prop="endpoint">
+            <el-input v-model="s3.endpoint" placeholder="Region name in lowercase" style="width: 80%" clearable></el-input>
           </el-form-item>
 
-          <el-form-item label="Access Key" prop="accessKey">
-            <el-input v-model="s3.accessKey" placeholder="Access Key" style="width: 80%" clearable
+          <el-form-item label="Access Key ID" prop="accessKey">
+            <el-input v-model="s3.accessKey" placeholder="Access Key ID" style="width: 80%" clearable
                       show-password=""></el-input>
           </el-form-item>
 
@@ -228,7 +228,7 @@
 
     </el-tabs>
 
-    
+
   </div>
 </template>
 


### PR DESCRIPTION
iamrole instance based access will provide better security. Access keys and secret keys need not be shared to the user of jifa. It will provide more security over the s3 bucket by removing access key and secret key dependency

If access keys and secret key fails then it will automatically check for iamrole access. 

reference:  https://aws.amazon.com/premiumsupport/knowledge-center/ec2-instance-access-s3-bucket/
