### PR TITLE
feat: specify query type for a prepared query view

### DIFF
--- a/frontend/src/components/heapdump/Query.vue
+++ b/frontend/src/components/heapdump/Query.vue
@@ -179,7 +179,7 @@
   const TEXT = 3
 
   export default {
-    props: ['file', 'preparedQuery'],
+    props: ['file', 'preparedQuery', 'preparedQueryType'],
     data() {
       return {
         ICONS,
@@ -412,8 +412,9 @@
     },
 
     created() {
-      if (this.preparedQuery) {
+      if (this.preparedQuery && this.preparedQueryType) {
         this.query = this.preparedQuery
+        this.queryType = this.preparedQueryType
         this.disabledInput = true
         this.search()
       } else {


### PR DESCRIPTION
This allows prepared query views to specify the query type (sql/oql) when passing the query

There are no existing in-tree users of prepared query views.

Allows passing of Calcite queries directly to a prepared query view, such as follows for showing atlas/spectator metrics.

```
<el-tab-pane name="atlasMetrics" lazy>
  <span slot="label"> Atlas metrics </span>
  <div v-bind:style="{ 'height': '100%', 'width': resultDivWidth}">
    <Query :file="file"
      queryType='sql'
      @outgoingRefsOfObj="outgoingRefsOfObj"
      @incomingRefsOfObj="incomingRefsOfObj"
      @outgoingRefsOfClass="outgoingRefsOfClass"
      @incomingRefsOfClass="incomingRefsOfClass"
      @pathToGCRootsOfObj="pathToGCRootsOfObj"
      @setSelectedObjectId="setSelectedObjectId"
      preparedQueryType='sql'
      preparedQuery='select m.name metric_name, count(*) metric_count from
        "com.netflix.spectator.api.DefaultId" m group by m.name order by metric_count desc' />
  </div>
</el-tab-pane>
```