### PR TITLE
UI improvement, User can specify more options at memory dump analysis scene & changing setting is cancelable after open the settings pannel.

### DIFF
--- a/analysis/heap-dump/provider/src/main/java/org/eclipse/jifa/hdp/provider/HeapDumpAnalysisApiExecutor.java
+++ b/analysis/heap-dump/provider/src/main/java/org/eclipse/jifa/hdp/provider/HeapDumpAnalysisApiExecutor.java
@@ -197,7 +197,9 @@ public class HeapDumpAnalysisApiExecutor extends AbstractApiExecutor<HeapDumpAna
 
     @Override
     protected void cachedAnalyzerRemoved(HeapDumpAnalyzer heapDumpAnalyzer) {
-        heapDumpAnalyzer.dispose();
+        if (heapDumpAnalyzer != null) {
+            heapDumpAnalyzer.dispose();
+        }
     }
 
     private File indexFile(Path target) {

--- a/analysis/src/main/java/org/eclipse/jifa/analysis/AbstractApiExecutor.java
+++ b/analysis/src/main/java/org/eclipse/jifa/analysis/AbstractApiExecutor.java
@@ -333,11 +333,11 @@ public abstract class AbstractApiExecutor<Analyzer> implements ApiExecutor {
     }
 
     public void release(@ApiParameterMeta(targetPath = true) Path target) {
-        cachedAnalyzer.invalidate(target);
+        cleanAndDisposeAnalyzerCache(target);
     }
 
     public void clean(@ApiParameterMeta(targetPath = true) Path target) {
-        cachedAnalyzer.invalidate(target);
+        cleanAndDisposeAnalyzerCache(target);
         File errorLog = errorLogFile(target);
         if (errorLog.exists()) {
             if (!errorLog.delete()) {
@@ -363,5 +363,14 @@ public abstract class AbstractApiExecutor<Analyzer> implements ApiExecutor {
      */
     protected int getCacheDuration() {
         return 8;
+    }
+
+    private void cleanAndDisposeAnalyzerCache(Path target) {
+        // Dispose snapshot synchronized to prevent from some problem caused by data inconsistency.
+        Analyzer analyzer = cachedAnalyzer.getIfPresent(target);
+        cachedAnalyzer.invalidate(target);
+        if (analyzer != null) {
+            cachedAnalyzerRemoved(analyzer);
+        }
     }
 }

--- a/frontend/src/components/Analysis.vue
+++ b/frontend/src/components/Analysis.vue
@@ -51,6 +51,21 @@ const progressStatus = computed(() => {
 function analyze(options?) {
   let parameters;
   if (options) {
+    options = { ...options };
+    let additionalOptions = options.additional_options;
+    delete options.additional_options;
+    if (additionalOptions && additionalOptions.trim()) {
+      const pairs = additionalOptions.match(/(\w+)=('(?:\\.|[^'\\])*'|\S+)/g);
+
+      for (let pair of pairs) {
+        const index = pair.indexOf('=');
+        const key = pair.slice(0, index);
+        const value = pair.slice(index + 1);
+        // delete qouta on value if exists.
+        const cleanedValue = value.replace(/^'(.*)'$/, '$1');
+        options[key] = cleanedValue
+      }
+    }
     parameters = { options };
   }
   request('analyze', parameters)

--- a/frontend/src/components/Analysis.vue
+++ b/frontend/src/components/Analysis.vue
@@ -180,6 +180,13 @@ onUnmounted(() => {
     <div class="ej-common-view-div" v-if="analysis.phase == Phase.INIT" v-loading="true"></div>
     <div
       class="ej-common-view-div"
+      style="display: flex; flex-direction: column; justify-content: center; align-items: center"
+      v-else-if="analysis.phase === Phase.SETUP || analysis.showSetupPage === true"
+    >
+      <component :is="setupComponent" @confirmAnalysisOptions="analyze"></component>
+    </div>
+    <div
+      class="ej-common-view-div"
       style="display: flex; flex-direction: column; justify-content: start"
       v-else-if="analysis.phase == Phase.ANALYZING || analysis.phase == Phase.FAILURE"
     >
@@ -202,13 +209,6 @@ onUnmounted(() => {
         <p style="font-weight: bold">{{ t('analysis.log') }}</p>
         <p v-if="log" style="white-space: pre-line">{{ log }}</p>
       </div>
-    </div>
-    <div
-      class="ej-common-view-div"
-      style="display: flex; flex-direction: column; justify-content: center; align-items: center"
-      v-else-if="analysis.phase === Phase.SETUP"
-    >
-      <component :is="setupComponent" @confirmAnalysisOptions="analyze"></component>
     </div>
     <component :is="analysisComponent" v-else-if="analysis.phase == Phase.SUCCESS"></component>
   </transition>

--- a/frontend/src/components/heapdump/Setup.vue
+++ b/frontend/src/components/heapdump/Setup.vue
@@ -19,12 +19,18 @@ const emit = defineEmits(['confirmAnalysisOptions']);
 
 const options = reactive({
   keep_unreachable_objects: true,
-  strictness: 'stop'
+  strictness: 'stop',
+  discard_objects: false,
+  discard_pattern: '',
+  discard_ratio: 0,
+  additional_options: ''
 });
 
 function onConfirm() {
   emit('confirmAnalysisOptions', options);
 }
+
+const enableDiscard = computed(() => options.discard_objects);
 </script>
 <template>
   <el-form
@@ -95,9 +101,100 @@ function onConfirm() {
       </el-popover>
     </el-form-item>
 
+    <!-- Discard Objects -->
+    <el-form-item :label="hdt('option.labelOfDiscardObjects')">
+      <el-switch v-model="options.discard_objects"></el-switch>
+      <el-popover
+        placement="top"
+        :width="600"
+        trigger="hover"
+        :show-arrow="false"
+        :popper-style="{ padding: 0 }"
+      >
+        <template #reference>
+          <el-icon class="ej-icon" style="margin-left: 8px" size="18">
+            <InfoFilled />
+          </el-icon>
+        </template>
+        <template #default>
+          <el-alert
+            type="info"
+            style="word-break: keep-all"
+            :closable="false"
+            :title="hdt('option.descOfDiscardObjects')"
+          >
+            <div slot="default">
+              <p>{{ hdt('option.descOfDiscardObjectsDetail') }}</p>
+              <p>discard_pattern: {{ hdt('option.descOfDiscardObjectsPattern') }}</p>
+              <p>discard_ratio: {{ hdt('option.descOfDiscardObjectsRatio') }}</p>
+            </div>
+          </el-alert>
+        </template>
+      </el-popover>
+    </el-form-item>
+    <el-form-item :label="hdt('option.labelOfDiscardObjectsPattern')" v-if="enableDiscard">
+      <el-input
+        v-model="options.discard_pattern"
+        placeholder="eg:byte\[\]|java\.lang\.String||java\.lang\.String\[\]"
+        clearable
+        class="discard-pattern-form-input"
+        @keydown.enter="(e) => e.preventDefault()"
+      > </el-input>
+    </el-form-item>
+    <el-form-item :label="hdt('option.labelOfDiscardObjectsRatio')" v-if="enableDiscard">
+      <el-input
+        v-model="options.discard_ratio"
+        placeholder="0~100"
+        class="discard-ratio-form-input"
+        @keydown.enter="(e) => e.preventDefault()"
+      > </el-input>
+    </el-form-item>
+    <!-- Discard Objects end -->
+    <el-form-item :label="hdt('option.labelAdditionalAnalyseOptions')">
+      <el-input
+        v-model="options.additional_options"
+        placeholder="options for eclipse memory analyser, eg: k1=v1 k2=v2 k3='v3 with blank characters'"
+        class="additional-options-form-input"
+        clearable
+        @keydown.enter="(e) => e.preventDefault()"
+      > </el-input>
+      <el-popover
+        placement="top"
+        :width="600"
+        trigger="hover"
+        :show-arrow="false"
+        :popper-style="{ padding: 0 }"
+      >
+        <template #reference>
+          <el-icon class="ej-icon" style="margin-left: 8px" size="18">
+            <InfoFilled />
+          </el-icon>
+        </template>
+        <template #default>
+          <el-alert
+            type="info"
+            style="word-break: keep-all"
+            :closable="false"
+            :description="hdt('option.descAdditionalAnalyseOptions')"
+          >
+          </el-alert>
+        </template>
+      </el-popover>
+    </el-form-item>
     <el-form-item>
       <el-button type="primary" @click="onConfirm">{{ t('common.confirm') }}</el-button>
     </el-form-item>
   </el-form>
 </template>
-<style scoped></style>
+<style scoped>
+.discard-ratio-form-input {
+  width: 120px;
+}
+.discard-pattern-form-input {
+  width: 420px;
+}
+
+.additional-options-form-input {
+  width: 350px;
+}
+</style>

--- a/frontend/src/components/heapdump/Setup.vue
+++ b/frontend/src/components/heapdump/Setup.vue
@@ -12,8 +12,14 @@
  -->
 <script setup lang="ts">
 import { hdt } from '@/components/heapdump/utils';
+import { Phase, useAnalysisStore } from '@/stores/analysis';
 import { InfoFilled } from '@element-plus/icons-vue';
 import { t } from '@/i18n/i18n';
+
+import { useAnalysisApiRequester } from '@/composables/analysis-api-requester';
+
+const { request } = useAnalysisApiRequester();
+const analysis = useAnalysisStore();
 
 const emit = defineEmits(['confirmAnalysisOptions']);
 
@@ -27,7 +33,16 @@ const options = reactive({
 });
 
 function onConfirm() {
-  emit('confirmAnalysisOptions', options);
+  request('clean').then(() => {
+    analysis.leaveGuard = false;
+    analysis.setPhase(Phase.INIT)
+    analysis.setShowSetupPage(false);
+    emit('confirmAnalysisOptions', options);
+  });
+}
+
+function onCancel() {
+  analysis.setShowSetupPage(false);
 }
 
 const enableDiscard = computed(() => options.discard_objects);
@@ -183,6 +198,9 @@ const enableDiscard = computed(() => options.discard_objects);
     </el-form-item>
     <el-form-item>
       <el-button type="primary" @click="onConfirm">{{ t('common.confirm') }}</el-button>
+      <el-button @click="onCancel" v-if="analysis.phase !== Phase.INIT && analysis.phase !== Phase.SETUP">
+        {{ t('common.cancel') }}
+      </el-button>
     </el-form-item>
   </el-form>
 </template>

--- a/frontend/src/components/heapdump/Toolbar.vue
+++ b/frontend/src/components/heapdump/Toolbar.vue
@@ -20,12 +20,11 @@ import { Phase, useAnalysisStore } from '@/stores/analysis';
 const { request } = useAnalysisApiRequester();
 
 const analysis = useAnalysisStore();
-function clean() {
-  request('clean').then(() => {
-    useAnalysisStore().leaveGuard = false;
-    location.reload();
-  });
+
+function showSetup() {
+  analysis.setShowSetupPage(true)
 }
+
 </script>
 <template>
   <el-divider direction="vertical" />
@@ -34,7 +33,7 @@ function clean() {
   <template v-if="analysis.phase === Phase.SUCCESS || analysis.phase === Phase.FAILURE">
     <el-divider direction="vertical" />
 
-    <el-button link class="ej-header-button" :icon="SetUp" @click="clean">
+    <el-button link class="ej-header-button" :icon="SetUp" @click="showSetup">
       {{ t('analysis.setting') }}
     </el-button>
   </template>

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -18,6 +18,7 @@ export default {
   jifa: {
     common: {
       confirm: 'Confirm',
+      cancel: 'Cancel',
       submit: 'Submit',
       back: 'Back',
       operations: 'Operations',

--- a/frontend/src/i18n/heapdump/en.ts
+++ b/frontend/src/i18n/heapdump/en.ts
@@ -19,7 +19,16 @@ export default {
     descOfStrictness: "'Strictness' indicates the follow-up action when an error occurred",
     descOfStopStrictness: 'Throw an error and stop analyzing the dump',
     descOfWarnStrictness: 'Raise a warning and continue',
-    descOfPermissiveStrictness: 'Raise a warning and try to "fix" it'
+    descOfPermissiveStrictness: 'Raise a warning and try to "fix" it',
+    labelOfDiscardObjects: 'Discard objects',
+    descOfDiscardObjects: 'Discard some objects to reduce memory consume while analyse',
+    descOfDiscardObjectsDetail: 'Sometimes a heap dump is generated with more objects than Memory Analyzer can handle, either from lack of heap to run Memory Analyzer itself, or because the number exceeds the Memory Analyzer limit of 2,147,483,639 objects. This option controls some experimental settings to help analyze such huge dumps, by purposely discarding objects in the original heap dump.',
+    labelOfDiscardObjectsRatio: "Discard ratio",
+    descOfDiscardObjectsRatio: 'A number between 0 and 100, treated as a percentage. Approximately this percentage of ordinary objects matching the discard pattern will be discarded by the HPROF or DTFJ parsers.',
+    labelOfDiscardObjectsPattern: 'Discard pattern',
+    descOfDiscardObjectsPattern: 'Only objects with a class name matching this regular expression will be discarded. It is best to chose objects of a type which does not link to other objects, such as primitive arrays, or objects which just link to other such objects. This avoids breaking the object graph too much, and gives a hope that the leak analysis will find the problem.',
+    labelAdditionalAnalyseOptions: 'Additional options',
+    descAdditionalAnalyseOptions: 'Analyse options of Eclipse Memory Analyser, see: https://help.eclipse.org/latest/index.jsp?topic=%2Forg.eclipse.mat.ui.help%2Ftasks%2Fconfigure_mat.html'
   },
 
   tab: {

--- a/frontend/src/i18n/heapdump/zh.ts
+++ b/frontend/src/i18n/heapdump/zh.ts
@@ -19,7 +19,16 @@ export default {
     descOfStrictness: "'分析失败时的策略' 表示当分析过程中遇到错误时的后续动作",
     descOfStopStrictness: '终止分析',
     descOfWarnStrictness: '报告警告信息并继续分析',
-    descOfPermissiveStrictness: '报告警告信息，尝试修复错误并继续分析'
+    descOfPermissiveStrictness: '报告警告信息，尝试修复错误并继续分析',
+    labelOfDiscardObjects: '丢弃部分对象',
+    descOfDiscardObjects: '分析的时候丢弃部分对象，以减少 jifa 的堆内存占用，防止 OOM',
+    descOfDiscardObjectsDetail: '如果堆内存特别巨大的话，其中某一类 objects 的数量可能会超过 2,147,483,639 这个限制，从而导致 1. analyze 无法为其创建索引数组而解析失败, 2. jifa 本身OOM 而解析失败. 这个选项可以通过指定丢弃类和丢弃比例的方式来丢弃一部分 objects，从而避免这些问题（如果堆内存特别巨大，建议开启此选项）',
+    labelOfDiscardObjectsRatio: "丢弃比例",
+    descOfDiscardObjectsRatio: '丢弃的百分比，数值范围：0 ~ 100. 匹配了 discard pattern 的类将会被根据这个比例进行随机丢弃.',
+    labelOfDiscardObjectsPattern: '丢弃规则',
+    descOfDiscardObjectsPattern: '丢弃类的正则匹配表达式，最好选择一些不会引用其他 object 的类，例如: byte\\[\\]，java\\.lang\\.String\ 或者 java\\.lang\\.String\\[\\] （记得对关键字进行转义）.',
+    labelAdditionalAnalyseOptions: '其他选项',
+    descAdditionalAnalyseOptions: 'Eclipse Memory Analyser 支持的其他选项, 详情: https://help.eclipse.org/latest/index.jsp?topic=%2Forg.eclipse.mat.ui.help%2Ftasks%2Fconfigure_mat.html'
   },
 
   tab: {

--- a/frontend/src/i18n/zh.ts
+++ b/frontend/src/i18n/zh.ts
@@ -18,6 +18,7 @@ export default {
   jifa: {
     common: {
       confirm: '确定',
+      cancel: '取消',
       submit: '提交',
       back: '返回',
       operations: '操作',

--- a/frontend/src/stores/analysis.ts
+++ b/frontend/src/stores/analysis.ts
@@ -31,7 +31,9 @@ export const useAnalysisStore = defineStore('analysis', {
 
     phase: null as Phase | null,
 
-    leaveGuard: true
+    leaveGuard: true,
+
+    showSetupPage: false
   }),
 
   actions: {
@@ -47,6 +49,10 @@ export const useAnalysisStore = defineStore('analysis', {
 
     setPhase(phase: Phase | null) {
       this.phase = phase;
+    },
+
+    setShowSetupPage(showSetupPage: boolean) {
+      this.showSetupPage = showSetupPage
     }
   }
 });

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -57,4 +57,7 @@ export default defineConfig({
       }
     }
   },
+  build: {
+    chunkSizeWarningLimit: 10240
+  }
 })


### PR DESCRIPTION
### 1. User can specify more options at memory dump analysis scene.
Analyse could be faild caused by OOM(exceed limit of maximum length of array) if the dump file is very large. This problem can be solved by specify discard-object options. see: [Eclipse help](https://help.eclipse.org/latest/topic/org.eclipse.mat.ui.help/tasks/configure_mat.html#task_configure_mat__discard) .
Improve UI so user can specify those options.

### 2. UI improvement, user can cancel changing the settings (re-analysis dump file) after they open the setting panel in dump analysis scene.

before: dump analysis cache will dispose once user click 'Setting' button, it does not make sense.
now: dispose and re-analyse will performd sequencely only after use submit the new settings, but if user click the 'cancel' button after open the settins pannel, the pannel will closed and nothing else would happend.

