### PR TITLE
bugfix: add tooltip to display full text (e.g. Method, Class, Thread)

### DIFF
--- a/frontend/src/components/jfr/Jfr.vue
+++ b/frontend/src/components/jfr/Jfr.vue
@@ -36,7 +36,7 @@ const filter = ref(null);
 const toggleFilterValuesChecked = ref(true);
 const flameGraphDataSource = ref(null);
 const flameGraphEmptyData = ref({ format: 'line', data: [] });
-const taskName = ref(null);
+const taskName = ref('');
 const flameGraphModalVisible = ref(false);
 const hasData = ref(false);
 
@@ -202,6 +202,8 @@ async function queryFlameGraph(include: boolean, taskSet: any) {
 
 function onDimensionIndexChange() {
   toggleFilterValuesChecked.value = true;
+  selectedFilterIndex.value = 0;
+  taskName.value = '';
   queryGraph();
 }
 
@@ -211,6 +213,7 @@ async function onSelectedFilterIndexChange() {
     let filterName =
       perfDimensions.value[selectedDimensionIndex.value].filters[selectedFilterIndex.value].key;
     await queryFlameGraph(false, []);
+    taskName.value = '';
     if (filterName === 'Thread') {
       buildFilterValueByThreads();
     } else if (filterName === 'Class') {
@@ -598,9 +601,16 @@ onUnmounted(() => {});
                       "
                     >
                       <div>
-                        <el-text truncated>
-                          {{ data.key }}
-                        </el-text>
+                        <el-tooltip
+                          class="box-item"
+                          effect="dark"
+                          :content="data.key"
+                          placement="bottom"
+                        >
+                          <el-text truncated>
+                            {{ data.key }}
+                          </el-text>
+                        </el-tooltip>
                       </div>
                       <div>
                         <el-text tag="b" size="small" truncated>


### PR DESCRIPTION
hi all

Could I have a review of this patch. I would be very grateful.

If Thread /Class/Method name is truncated, now we can not see the full name.
This patch adds a tooltip to display the full name.

before the patch:
![image](https://github.com/eclipse/jifa/assets/24515208/17015899-2458-4fa6-8dfa-ad9faa19d3e6)

after the patch:
![image](https://github.com/eclipse/jifa/assets/24515208/44091ca1-fa2c-427d-8e8f-bad4e566ceff)

This patch also fixed another bug.
If dimension or filter-index(Thread/Class/Method) changed, clear the text of the Thread name input.
