### PR TITLE
feature: add worker image pull secret name

### DIFF
--- a/server/src/main/java/org/eclipse/jifa/server/Configuration.java
+++ b/server/src/main/java/org/eclipse/jifa/server/Configuration.java
@@ -99,6 +99,11 @@ public class Configuration {
     private String serviceAccountName;
 
     /**
+     * The name of image pull secret
+     */
+    private String imagePullSecretName;
+
+    /**
      * The container image of elastic workers.
      */
     private String elasticWorkerImage;

--- a/server/src/main/java/org/eclipse/jifa/server/service/impl/K8SWorkerScheduler.java
+++ b/server/src/main/java/org/eclipse/jifa/server/service/impl/K8SWorkerScheduler.java
@@ -23,6 +23,7 @@ import io.kubernetes.client.openapi.models.V1ContainerPort;
 import io.kubernetes.client.openapi.models.V1ContainerStatus;
 import io.kubernetes.client.openapi.models.V1EnvVar;
 import io.kubernetes.client.openapi.models.V1HTTPGetAction;
+import io.kubernetes.client.openapi.models.V1LocalObjectReference;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1PersistentVolumeClaimVolumeSource;
 import io.kubernetes.client.openapi.models.V1Pod;
@@ -125,6 +126,13 @@ public class K8SWorkerScheduler extends ConfigurationAccessor implements Elastic
                 V1PodSpec podSpec = new V1PodSpec().addContainersItem(container).addVolumesItem(volume)
                                                    .serviceAccountName(config.getServiceAccountName())
                                                    .restartPolicy("Never");
+
+                String imagePullSecretName = config.getImagePullSecretName();
+                if (StringUtils.isNotBlank(imagePullSecretName)) {
+                    podSpec.addImagePullSecretsItem(new V1LocalObjectReference()
+                            .name(imagePullSecretName));
+                }
+
                 // workaround for https://github.com/kubernetes-client/java/issues/3076
                 podSpec.setOverhead(null);
                 pod.spec(podSpec);

--- a/site/docs/guide/configuration.md
+++ b/site/docs/guide/configuration.md
@@ -86,6 +86,14 @@ Type: String
 
 Default: null
 
+## image-pull-secret-name
+
+The name of image pull secret
+
+Type: String
+
+Default: null
+
 ## elastic-worker-image
 
 Docker image used in the cluster to run `ELASTIC_WORKER` nodes.

--- a/site/docs/zh/guide/configuration.md
+++ b/site/docs/zh/guide/configuration.md
@@ -85,6 +85,14 @@
 
 默认值: null
 
+## image-pull-secret-name
+
+集群中用于拉取 `WORKER` 镜像的密钥的名字。
+
+类型: String
+
+默认值: null
+
 ## elastic-worker-image
 
 集群中用于运行 `WORKER` 节点的镜像。


### PR DESCRIPTION
Hi, all

Could I have a review for this patch. I would be very grateful.

The official image is out of date, so I built an image and pushed it to our private registry, then found that it needs set pull secret to pull the elastic worker image from the private registry.

This patch adds the `image-pull-secret-name` option to the master node so that it can pull image from the private registry when scheduling a worker pod.

Thanks

