### PR TITLE
feat: add support to disable spring security web filters

### DIFF
--- a/server/src/main/java/org/eclipse/jifa/server/Configuration.java
+++ b/server/src/main/java/org/eclipse/jifa/server/Configuration.java
@@ -166,6 +166,13 @@ public class Configuration {
      */
     private Set<FileTransferMethod> disabledFileTransferMethods = Collections.emptySet();
 
+    /**
+     * Install the web security filters. Default is true.
+     *
+     * Use this to allow integration with custom security filters.
+     */
+    private boolean securityFiltersEnabled = true;
+
     @PostConstruct
     private void init() {
         if (role == Role.MASTER) {

--- a/server/src/main/java/org/eclipse/jifa/server/configurer/SecurityCryptoConfigurer.java
+++ b/server/src/main/java/org/eclipse/jifa/server/configurer/SecurityCryptoConfigurer.java
@@ -1,0 +1,59 @@
+/********************************************************************************
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ********************************************************************************/
+package org.eclipse.jifa.server.configurer;
+
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jose.jwk.source.ImmutableJWKSet;
+import org.eclipse.jifa.server.ConfigurationAccessor;
+import org.eclipse.jifa.server.service.CipherService;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtEncoder;
+import org.springframework.security.oauth2.jwt.JwtTimestampValidator;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtEncoder;
+import java.time.Duration;
+
+import static org.eclipse.jifa.server.enums.Role.MASTER;
+import static org.eclipse.jifa.server.enums.Role.STANDALONE_WORKER;
+
+@Configuration
+public class SecurityCryptoConfigurer extends ConfigurationAccessor {
+
+    @Bean
+    public JwtEncoder jwtEncoder(CipherService cipherService) {
+        RSAKey jwk = new RSAKey.Builder(cipherService.getPublicKey()).privateKey(cipherService.getPrivateKey()).build();
+        return new NimbusJwtEncoder(new ImmutableJWKSet<>(new JWKSet(jwk)));
+    }
+
+    @Bean
+    @Primary
+    public JwtDecoder jwtDecoder(CipherService cipherService) {
+        NimbusJwtDecoder decoder = NimbusJwtDecoder.withPublicKey(cipherService.getPublicKey()).build();
+
+        if (getRole() == MASTER || getRole() == STANDALONE_WORKER) {
+            decoder.setJwtValidator(new JwtTimestampValidator(Duration.ZERO));
+        }
+        return decoder;
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}


### PR DESCRIPTION
this allows a user to provide their own web filters by setting `jifa.security-filters-enabled: false`

the default is to have security filters enabled (ie: true)