### PR TITLE
fix: obtain the correct IP address for the static worker

### DIFF
--- a/server/src/main/java/org/eclipse/jifa/server/component/CurrentStaticWorker.java
+++ b/server/src/main/java/org/eclipse/jifa/server/component/CurrentStaticWorker.java
@@ -80,7 +80,7 @@ public class CurrentStaticWorker extends ConfigurationAccessor {
         current = staticWorkerRepo.save(current);
     }
 
-    public String getLocalHostExactAddress() throws IOException {
+    private String getLocalHostExactAddress() throws IOException {
         Enumeration<NetworkInterface> allNetworkInterfaces = NetworkInterface.getNetworkInterfaces();
         while (allNetworkInterfaces.hasMoreElements()) {
             NetworkInterface networkInterface = allNetworkInterfaces.nextElement();

--- a/server/src/main/java/org/eclipse/jifa/server/component/CurrentStaticWorker.java
+++ b/server/src/main/java/org/eclipse/jifa/server/component/CurrentStaticWorker.java
@@ -50,8 +50,7 @@ public class CurrentStaticWorker extends ConfigurationAccessor {
 
     @PostConstruct
     private void init() throws IOException {
-        InetAddress localHost = getLocalHostExactAddress();
-        String hostAddress = localHost.getHostAddress();
+        String hostAddress = getLocalHostExactAddress();
         current = this.staticWorkerRepo.findByHostAddress(hostAddress).orElseGet(() -> {
             StaticWorkerEntity worker = new StaticWorkerEntity();
             worker.setHostAddress(hostAddress);
@@ -79,25 +78,20 @@ public class CurrentStaticWorker extends ConfigurationAccessor {
         current = staticWorkerRepo.save(current);
     }
 
-    private InetAddress getLocalHostExactAddress() {
-        try {
-            Enumeration<NetworkInterface> allNetworkInterfaces = NetworkInterface.getNetworkInterfaces();
-            while (allNetworkInterfaces.hasMoreElements()) {
-                NetworkInterface networkInterface = allNetworkInterfaces.nextElement();
-                if (!networkInterface.isLoopback() && !networkInterface.isVirtual() && networkInterface.isUp()) {
-                    Enumeration<InetAddress> addresses = networkInterface.getInetAddresses();
-                    while (addresses.hasMoreElements()) {
-                        InetAddress inetAddress = addresses.nextElement();
-                        if (inetAddress instanceof Inet4Address) {
-                            return inetAddress;
-                        }
+    public String getLocalHostExactAddress() throws SocketException, UnknownHostException {
+        Enumeration<NetworkInterface> allNetworkInterfaces = NetworkInterface.getNetworkInterfaces();
+        while (allNetworkInterfaces.hasMoreElements()) {
+            NetworkInterface networkInterface = allNetworkInterfaces.nextElement();
+            if (!networkInterface.isLoopback() && !networkInterface.isVirtual() && networkInterface.isUp()) {
+                Enumeration<InetAddress> addresses = networkInterface.getInetAddresses();
+                while (addresses.hasMoreElements()) {
+                    InetAddress inetAddress = addresses.nextElement();
+                    if (inetAddress instanceof Inet4Address) {
+                        return inetAddress.getHostAddress();
                     }
                 }
             }
-            return InetAddress.getLocalHost();
-        } catch (Exception e) {
-            e.printStackTrace();
         }
-        return null;
+        return InetAddress.getLocalHost().getHostAddress();
     }
 }

--- a/server/src/main/java/org/eclipse/jifa/server/component/CurrentStaticWorker.java
+++ b/server/src/main/java/org/eclipse/jifa/server/component/CurrentStaticWorker.java
@@ -80,7 +80,7 @@ public class CurrentStaticWorker extends ConfigurationAccessor {
         current = staticWorkerRepo.save(current);
     }
 
-    public String getLocalHostExactAddress() throws SocketException, UnknownHostException {
+    public String getLocalHostExactAddress() throws IOException {
         Enumeration<NetworkInterface> allNetworkInterfaces = NetworkInterface.getNetworkInterfaces();
         while (allNetworkInterfaces.hasMoreElements()) {
             NetworkInterface networkInterface = allNetworkInterfaces.nextElement();

--- a/server/src/main/java/org/eclipse/jifa/server/component/CurrentStaticWorker.java
+++ b/server/src/main/java/org/eclipse/jifa/server/component/CurrentStaticWorker.java
@@ -26,6 +26,8 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.time.Duration;
 import java.time.Instant;
+import java.net.*;
+import java.util.Enumeration;
 
 @StaticWorker
 @Component


### PR DESCRIPTION
Fix the problem that the static worker node obtains the loopback address as the IP address. I have tested this method on Linux and Windows and found no problems. However, I currently haven't found a good way to solve the problem of obtaining IP addresses under multiple network cards.