### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,5 @@ ARG DEPENDENCY=/workspace/server/build/dependency
 COPY --from=build ${DEPENDENCY}/BOOT-INF/lib /jifa/lib
 COPY --from=build ${DEPENDENCY}/META-INF /jifa/META-INF
 COPY --from=build ${DEPENDENCY}/BOOT-INF/classes /jifa
+EXPOSE 8102
 ENTRYPOINT ["java","--add-opens=java.base/java.lang=ALL-UNNAMED","--add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED","-Djdk.util.zip.disableZip64ExtraFieldValidation=true","-cp","jifa:jifa/lib/*","org.eclipse.jifa.server.Launcher"]


### PR DESCRIPTION
Dockerfile does not expose ports, resulting in the inability to set ports when running images in Docker Desktop.

<img width="524" alt="image" src="https://github.com/user-attachments/assets/b9d70e5c-4f2d-4c74-922e-bd9d29ca4f32">