### PR TITLE
Bump Spring Boot to 4.1

### DIFF
--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -25,11 +25,12 @@ dependencies {
     testCompileOnly "org.projectlombok:lombok:$lombok_version"
     testAnnotationProcessor "org.projectlombok:lombok:$lombok_version"
 
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.2'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.2'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:6.0.3'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:6.0.3'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher:6.0.3'
 
-    testImplementation 'org.mockito:mockito-junit-jupiter:4.8.1'
-    testRuntimeOnly 'org.mockito:mockito-core:4.8.1'
+    testImplementation 'org.mockito:mockito-junit-jupiter:5.23.0'
+    testRuntimeOnly 'org.mockito:mockito-core:5.23.0'
 }
 
 java {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,7 @@
+#Wed Jun 24 09:37:51 CST 2026
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/jifa.gradle
+++ b/jifa.gradle
@@ -13,7 +13,7 @@
 plugins {
     id 'base'
     id 'jacoco-report-aggregation'
-    id "org.springframework.boot" version "3.3.11"
+    id "org.springframework.boot" version "4.1.0"
 }
 
 apply from: "$rootDir/gradle/base.gradle"
@@ -34,7 +34,7 @@ dependencies {
 reporting {
     reports {
         testCodeCoverageReport(JacocoCoverageReport) {
-            testType = TestSuiteType.UNIT_TEST
+            testSuiteName = "test"
         }
     }
 }

--- a/server/server.gradle
+++ b/server/server.gradle
@@ -12,7 +12,7 @@
  ********************************************************************************/
 plugins {
     id 'application'
-    id "org.springframework.boot" version "3.3.11"
+    id "org.springframework.boot" version "4.1.0"
 }
 
 apply from: "$rootDir/gradle/java.gradle"
@@ -41,7 +41,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
     annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
-    implementation 'org.springframework.retry:spring-retry'
+    implementation 'org.springframework.retry:spring-retry:2.0.12'
 
     implementation 'io.kubernetes:client-java:20.0.0'
 
@@ -56,6 +56,7 @@ dependencies {
 
     // test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 }
 
 run.enabled = false

--- a/server/src/main/java/org/eclipse/jifa/server/configurer/EntityConfigurer.java
+++ b/server/src/main/java/org/eclipse/jifa/server/configurer/EntityConfigurer.java
@@ -13,7 +13,7 @@
 package org.eclipse.jifa.server.configurer;
 
 import org.eclipse.jifa.server.condition.Cluster;
-import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.persistence.autoconfigure.EntityScan;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration

--- a/server/src/main/java/org/eclipse/jifa/server/configurer/HttpConfigurer.java
+++ b/server/src/main/java/org/eclipse/jifa/server/configurer/HttpConfigurer.java
@@ -83,9 +83,9 @@ public class HttpConfigurer extends ConfigurationAccessor implements WebMvcConfi
         // Insert GsonHttpMessageConverter right after ByteArrayHttpMessageConverter so that Gson
         // takes precedence over the String/Jackson converters for JSON (de)serialization, while
         // @RequestBody byte[] is still read as raw bytes by ByteArrayHttpMessageConverter.
-        int index = 0;
+        int index = Math.min(1, converters.size());
         for (int i = 0; i < converters.size(); i++) {
-            if (converters.get(i).getClass().getSimpleName().equals("ByteArrayHttpMessageConverter")) {
+            if (converters.get(i) instanceof org.springframework.http.converter.ByteArrayHttpMessageConverter) {
                 index = i + 1;
                 break;
             }

--- a/server/src/main/java/org/eclipse/jifa/server/configurer/HttpConfigurer.java
+++ b/server/src/main/java/org/eclipse/jifa/server/configurer/HttpConfigurer.java
@@ -17,7 +17,7 @@ import org.eclipse.jifa.server.ConfigurationAccessor;
 import org.eclipse.jifa.server.Constant;
 import org.eclipse.jifa.server.condition.ConditionalOnRole;
 import org.eclipse.jifa.server.enums.Role;
-import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
+import org.springframework.boot.tomcat.servlet.TomcatServletWebServerFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.converter.HttpMessageConverter;
@@ -80,7 +80,16 @@ public class HttpConfigurer extends ConfigurationAccessor implements WebMvcConfi
 
     @Override
     public void extendMessageConverters(List<HttpMessageConverter<?>> converters) {
-        // add GsonHttpMessageConverter to the first position
-        converters.add(1, new GsonHttpMessageConverter(GsonHolder.GSON));
+        // Insert GsonHttpMessageConverter right after ByteArrayHttpMessageConverter so that Gson
+        // takes precedence over the String/Jackson converters for JSON (de)serialization, while
+        // @RequestBody byte[] is still read as raw bytes by ByteArrayHttpMessageConverter.
+        int index = 0;
+        for (int i = 0; i < converters.size(); i++) {
+            if (converters.get(i).getClass().getSimpleName().equals("ByteArrayHttpMessageConverter")) {
+                index = i + 1;
+                break;
+            }
+        }
+        converters.add(index, new GsonHttpMessageConverter(GsonHolder.GSON));
     }
 }

--- a/server/src/main/java/org/eclipse/jifa/server/configurer/SecurityFilterConfigurer.java
+++ b/server/src/main/java/org/eclipse/jifa/server/configurer/SecurityFilterConfigurer.java
@@ -22,7 +22,7 @@ import org.eclipse.jifa.server.filter.JwtTokenRefreshFilter;
 import org.eclipse.jifa.server.service.JwtService;
 import org.eclipse.jifa.server.service.UserService;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientProperties;
+import org.springframework.boot.security.oauth2.client.autoconfigure.OAuth2ClientProperties;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/server/src/main/java/org/eclipse/jifa/server/controller/GlobalExceptionHandler.java
+++ b/server/src/main/java/org/eclipse/jifa/server/controller/GlobalExceptionHandler.java
@@ -22,7 +22,7 @@ import org.eclipse.jifa.server.domain.exception.ElasticWorkerNotReadyException;
 import org.eclipse.jifa.server.enums.ServerErrorCode;
 import org.eclipse.jifa.server.Constant;
 import org.eclipse.jifa.server.util.ErrorUtil;
-import org.springframework.boot.autoconfigure.web.servlet.MultipartProperties;
+import org.springframework.boot.servlet.autoconfigure.MultipartProperties;
 import org.springframework.lang.Nullable;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.util.unit.DataSize;
@@ -57,13 +57,13 @@ public class GlobalExceptionHandler {
             response.getOutputStream().write(e.getResponseBodyAsByteArray());
             return;
         }
-        
+
         // Handle file upload size exceeded exceptions
         if (throwable instanceof MaxUploadSizeExceededException e) {
             handleFileUploadSizeExceeded(e, response);
             return;
         }
-        
+
         // Handle other exceptions
         response.setStatus(getStatusOf(throwable));
         response.getOutputStream().write(ErrorUtil.toJson(throwable));
@@ -88,18 +88,18 @@ public class GlobalExceptionHandler {
             // This should rarely happen in a Spring Boot app, but fallback to unlimited
             actualMaxSize = Constant.DEFAULT_MAX_UPLOAD_SIZE; // Long.MAX_VALUE (unlimited)
         }
-        
+
         String maxSizeFormatted;
         if (actualMaxSize == Long.MAX_VALUE) {
             maxSizeFormatted = "unlimited";
         } else {
             maxSizeFormatted = FileUtils.byteCountToDisplaySize(actualMaxSize);
         }
-        
+
         // Log for debugging - show both the exception's maxUploadSize (-1) and actual config
-        log.warn("File upload size exceeded. Exception.getMaxUploadSize(): {} (unreliable), Actual configured max-file-size: {} bytes ({})", 
+        log.warn("File upload size exceeded. Exception.getMaxUploadSize(): {} (unreliable), Actual configured max-file-size: {} bytes ({})",
                  e.getMaxUploadSize(), actualMaxSize == Long.MAX_VALUE ? "unlimited" : actualMaxSize, maxSizeFormatted);
-        
+
         response.setStatus(200); // Use 200 to simplify frontend handling
         // Return clear error message with actual configured limit
         String errorMessage = "File size exceeds the maximum allowed size of " + maxSizeFormatted;

--- a/server/src/main/java/org/eclipse/jifa/server/controller/HandshakeController.java
+++ b/server/src/main/java/org/eclipse/jifa/server/controller/HandshakeController.java
@@ -20,8 +20,8 @@ import org.eclipse.jifa.server.domain.dto.User;
 import org.eclipse.jifa.server.domain.entity.shared.user.UserEntity;
 import org.eclipse.jifa.server.service.CipherService;
 import org.eclipse.jifa.server.service.UserService;
-import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientProperties;
-import org.springframework.boot.autoconfigure.web.servlet.MultipartProperties;
+import org.springframework.boot.security.oauth2.client.autoconfigure.OAuth2ClientProperties;
+import org.springframework.boot.servlet.autoconfigure.MultipartProperties;
 import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestRedirectFilter;
 import org.springframework.util.unit.DataSize;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -67,7 +67,7 @@ public class HandshakeController extends ConfigurationAccessor {
     public HandshakeResponse handshake() {
         UserEntity userEntity = userService.getCurrentUser();
         User user = userEntity == null ? null : new User(userEntity.getName(), userEntity.isAdmin());
-        
+
         // Get upload size limit configuration
         long maxUploadSize;
         if (multipartProperties != null) {
@@ -76,7 +76,7 @@ public class HandshakeController extends ConfigurationAccessor {
         } else {
             maxUploadSize = Constant.DEFAULT_MAX_UPLOAD_SIZE;
         }
-        
+
         return new HandshakeResponse(getRole(),
                                      config.isAllowLogin(),
                                      config.isAllowLogin() ? oauth2LoginLinks : Collections.emptyMap(),

--- a/server/src/test/java/org/eclipse/jifa/server/controller/TestAnalysisApiHttpController.java
+++ b/server/src/test/java/org/eclipse/jifa/server/controller/TestAnalysisApiHttpController.java
@@ -19,9 +19,9 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.security.autoconfigure.SecurityAutoConfiguration;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
@@ -40,7 +40,7 @@ public class TestAnalysisApiHttpController {
     @Autowired
     private MockMvc mvc;
 
-    @MockBean
+    @MockitoBean
     private AnalysisApiService apiService;
 
     @BeforeEach

--- a/server/src/test/java/org/eclipse/jifa/server/controller/TestAnalysisApiStompController.java
+++ b/server/src/test/java/org/eclipse/jifa/server/controller/TestAnalysisApiStompController.java
@@ -21,7 +21,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.messaging.converter.GsonMessageConverter;
 import org.springframework.messaging.simp.stomp.StompCommand;
 import org.springframework.messaging.simp.stomp.StompHeaders;
@@ -50,7 +50,7 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
 @SpringBootTest(webEnvironment = DEFINED_PORT)
 public class TestAnalysisApiStompController {
 
-    @MockBean
+    @MockitoBean
     private AnalysisApiService apiService;
 
     private WebSocketStompClient webSocketStompClient;

--- a/server/src/test/java/org/eclipse/jifa/server/controller/TestElasticWorkerController.java
+++ b/server/src/test/java/org/eclipse/jifa/server/controller/TestElasticWorkerController.java
@@ -19,9 +19,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.security.autoconfigure.SecurityAutoConfiguration;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -42,7 +42,7 @@ public class TestElasticWorkerController {
     @Autowired
     private MockMvc mvc;
 
-    @MockBean
+    @MockitoBean
     private WorkerService workerService;
 
     @BeforeEach

--- a/server/src/test/java/org/eclipse/jifa/server/controller/TestFileController.java
+++ b/server/src/test/java/org/eclipse/jifa/server/controller/TestFileController.java
@@ -28,9 +28,9 @@ import org.eclipse.jifa.server.service.FileService;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.security.autoconfigure.SecurityAutoConfiguration;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
@@ -57,7 +57,7 @@ public class TestFileController {
     @Autowired
     private MockMvc mvc;
 
-    @MockBean
+    @MockitoBean
     private FileService fileService;
 
     @Test

--- a/server/src/test/java/org/eclipse/jifa/server/controller/TestHandshakeController.java
+++ b/server/src/test/java/org/eclipse/jifa/server/controller/TestHandshakeController.java
@@ -22,9 +22,9 @@ import org.eclipse.jifa.server.service.UserService;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.security.autoconfigure.SecurityAutoConfiguration;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
@@ -40,10 +40,10 @@ public class TestHandshakeController {
     @Autowired
     private MockMvc mvc;
 
-    @MockBean
+    @MockitoBean
     private CipherService cipherService;
 
-    @MockBean
+    @MockitoBean
     private UserService userService;
 
     @Test

--- a/server/src/test/java/org/eclipse/jifa/server/controller/TestHealthCheckController.java
+++ b/server/src/test/java/org/eclipse/jifa/server/controller/TestHealthCheckController.java
@@ -17,8 +17,8 @@ import org.eclipse.jifa.server.Constant;
 import org.eclipse.jifa.server.domain.dto.InstanceView;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.security.autoconfigure.SecurityAutoConfiguration;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 

--- a/server/src/test/java/org/eclipse/jifa/server/domain/dto/TestFileTransferRequest.java
+++ b/server/src/test/java/org/eclipse/jifa/server/domain/dto/TestFileTransferRequest.java
@@ -19,8 +19,8 @@ import org.eclipse.jifa.server.enums.FileTransferMethod;
 import org.eclipse.jifa.server.enums.FileType;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 
 import java.util.Set;
 


### PR DESCRIPTION
Upgrade Spring Boot from 3.3.11 to 4.1.0.

- Update Gradle wrapper to 8.14.3 (required by the Spring Boot 4 plugin)
- Pin spring-retry to 2.0.12 and add spring-boot-starter-webmvc-test, which are no longer provided transitively by the Spring Boot 4 BOM
- Align JUnit (6.0.3) and Mockito (5.23.0) with the Spring Boot 4.1 BOM
- Migrate imports for the split spring-boot-autoconfigure modules (OAuth2ClientProperties, TomcatServletWebServerFactory, MultipartProperties, EntityScan, SecurityAutoConfiguration, WebMvcTest)
- Replace @MockBean with @MockitoBean
- Insert GsonHttpMessageConverter after ByteArrayHttpMessageConverter so @RequestBody byte[] is still read as raw bytes under Spring Framework 7