### PR TITLE
docs: sync documentation with recent code changes

### DIFF
--- a/site/docs/guide/changelog.md
+++ b/site/docs/guide/changelog.md
@@ -4,12 +4,25 @@
 
 ### Features
 
-- **File Upload Enhancement**: Add configurable file size limits with dynamic frontend validation
+- Add support for JFR analysis
+- GC log analysis: add support for metrics
+- Heap dump analysis: add more analysis options, and new tabs for JVM options and environment variables
+- Thread dump analysis: add support for JDK 21
+- Add support for packaging Jifa into a binary installation package via `jpackage` (standalone mode)
+- Add Helm charts for cluster deployment, and consolidate the static and elastic scheduling strategies
+- New configurations: `allow-login`, `open-browser-when-ready`, `disabled-file-transfer-methods`, `security-filters-enabled` and `cluster-namespace`
+- Add configurable file upload size limits with friendly error messages
 
 ### Improvements
 
-- Improved file upload user experience with immediate feedback on size violations
-- Enhanced error handling for file upload operations
+- Upgrade to Spring Boot 4.1 and Eclipse MAT 1.16.1
+- Open the browser automatically when the server is ready in standalone mode
+- Select the locale based on the browser language
+
+### Security
+
+- Disable the SCP file transfer method by default
+- Restrict the file transfer URL scheme to http(s)
 
 ## 0.2.0 (2023-10)
 

--- a/site/docs/guide/configuration.md
+++ b/site/docs/guide/configuration.md
@@ -70,6 +70,14 @@ Type：String
 
 Default：Read from the environment variable `MYSQL_PASSWORD`, and `jifa` is used if it's not set.
 
+## cluster-namespace
+
+The namespace used in the cluster.
+
+Type: String
+
+Default: `jifa`
+
 ## storage-pvc-name
 
 The name of PersistentVolumeClaim used in the cluster.
@@ -186,6 +194,31 @@ Local files to be analyzed, used only in `STANDALONE_WORKER` role.
 Type: Path[]
 
 Default: null
+
+## open-browser-when-ready
+
+Whether to open the browser automatically when the server is ready, used only in `STANDALONE_WORKER` role.
+
+Type: boolean
+
+Default: false
+
+## disabled-file-transfer-methods
+
+The disabled file transfer methods, which will not be shown on the file transfer page.
+
+Type: Enum[]
+
+- `OSS`
+- `S3`
+- `SCP`
+- `URL`
+- `TEXT`
+- `UPLOAD`
+
+Default: `[SCP]`, set by the default configuration file.
+
+Note: for the `URL` method, only `http` and `https` schemes are supported.
 
 ## File Upload Configuration
 

--- a/site/docs/guide/what-is-eclipse-jifa.md
+++ b/site/docs/guide/what-is-eclipse-jifa.md
@@ -15,7 +15,7 @@ Currently, Jifa primarily supports the following features:
 
 In terms of the design, Jifa consists of two main parts:
 
-- **Server**: a standard SpringBoot 3 application.
+- **Server**: a standard Spring Boot 4 application.
 
 - **Web UI**: based on Vue 3, Element Plus and other packages.
 

--- a/site/docs/zh/guide/changelog.md
+++ b/site/docs/zh/guide/changelog.md
@@ -1,5 +1,29 @@
 # 更新日志
 
+## 0.3.0（TBD）
+
+### 特性
+
+- 实现 JFR 分析
+- GC 日志分析：支持指标（Metrics）
+- 堆快照分析：支持更多分析选项，新增 JVM 参数和环境变量页签
+- 线程快照分析：支持 JDK 21
+- 支持通过 `jpackage` 将 Jifa 打包为二进制安装包（单机模式）
+- 新增用于集群部署的 Helm charts，合并静态与弹性调度策略
+- 新增配置项：`allow-login`、`open-browser-when-ready`、`disabled-file-transfer-methods`、`security-filters-enabled` 和 `cluster-namespace`
+- 支持配置文件上传大小限制，并提供友好的错误提示
+
+### 改进
+
+- 升级至 Spring Boot 4.1 和 Eclipse MAT 1.16.1
+- 单机模式下服务就绪后自动打开浏览器
+- 根据浏览器语言自动选择界面语言
+
+### 安全
+
+- 默认禁用 SCP 文件传输方式
+- 限制 URL 文件传输方式仅支持 http(s) 协议
+
 ## 0.2.0（2023-10）
 
 ### 特性

--- a/site/docs/zh/guide/configuration.md
+++ b/site/docs/zh/guide/configuration.md
@@ -69,6 +69,14 @@
 
 默认值：从环境变量 `MYSQL_PASSWORD` 中读取，若未设置则为 `jifa`。
 
+## cluster-namespace
+
+集群中使用的命名空间。
+
+类型：String
+
+默认值：`jifa`
+
 ## storage-pvc-name
 
 集群中使用的 PersistentVolumeClaim 名称。
@@ -184,6 +192,31 @@ Default: false
 类型：Path[]
 
 默认值：null
+
+## open-browser-when-ready
+
+服务就绪后是否自动打开浏览器，仅在 `STANDALONE_WORKER` 角色中使用。
+
+类型：boolean
+
+默认值：false
+
+## disabled-file-transfer-methods
+
+禁用的文件传输方式，被禁用的方式不会在文件传输页面中展示。
+
+类型：Enum[]
+
+- `OSS`
+- `S3`
+- `SCP`
+- `URL`
+- `TEXT`
+- `UPLOAD`
+
+默认值：`[SCP]`，由默认配置文件设置。
+
+注意：`URL` 方式仅支持 `http` 和 `https` 协议。
 
 ## 文件上传配置
 

--- a/site/docs/zh/guide/configuration.md
+++ b/site/docs/zh/guide/configuration.md
@@ -139,9 +139,9 @@
 
 当其值为 false 时，allow-anonymous-access 将被设置为 true，allow-registration 将被设置为 false。
 
-Type: boolean
+类型：boolean
 
-Default: false
+默认值：false
 
 ## allow-anonymous-access
 
@@ -149,7 +149,7 @@ Default: false
 
 类型：boolean
 
-默认值：ture
+默认值：true
 
 ## allow-registration
 

--- a/site/docs/zh/guide/what-is-eclipse-jifa.md
+++ b/site/docs/zh/guide/what-is-eclipse-jifa.md
@@ -14,7 +14,7 @@ Eclipse Jifa（简称 Jifa）的名字由 “**J**ava **I**ssues **F**inding **A
 
 在设计上，由两部分组成：
 
-- **服务端**： 标准的 SpringBoot 3 应用。
+- **服务端**： 标准的 Spring Boot 4 应用。
 
 - **Web UI**：基于 Vue 3 和 Element Plus 等框架实现。
 


### PR DESCRIPTION
## What does this PR do?

Syncs the documentation with code changes that have landed since the docs
were last updated:

- **Configuration doc**: add three missing entries — `cluster-namespace`,
  `open-browser-when-ready` and `disabled-file-transfer-methods` (including
  the enum values, the default `[SCP]` set by application.yml, and a note
  that the `URL` method only supports http/https after #392)
- **What is Eclipse Jifa**: update the server description from
  "SpringBoot 3" to "Spring Boot 4" (#390)
- **Changelog**: flesh out the 0.3.0 section based on commits since 0.2.0
  (JFR analysis #252, GC log metrics #237, JDK 21 thread dump support #370,
  jpackage #336, Helm charts #272, dependency upgrades #354/#355/#390, etc.),
  and add the previously missing 0.3.0 section to the Chinese changelog
- Fix a few typos in the Chinese configuration doc (`ture` → `true`, mixed
  English labels)

Both the English and Chinese docs are updated consistently. All descriptions
were verified against `Configuration.java` and `application.yml`.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation-only change, no code affected