### PR TITLE
perf(heap-dump): add SoftReference caches for BFS/string-scan/leak-re…

### DIFF
--- a/analysis/heap-dump/impl/src/main/java/org/eclipse/jifa/hda/impl/AnalysisContext.java
+++ b/analysis/heap-dump/impl/src/main/java/org/eclipse/jifa/hda/impl/AnalysisContext.java
@@ -14,16 +14,19 @@
 package org.eclipse.jifa.hda.impl;
 
 import org.eclipse.jifa.hda.api.Model;
+import org.eclipse.jifa.hda.api.Model.LeakReport;
 import org.eclipse.mat.query.IResult;
 import org.eclipse.mat.query.IResultTree;
 import org.eclipse.mat.query.refined.RefinedTable;
 import org.eclipse.mat.snapshot.ISnapshot;
 
 import java.lang.ref.SoftReference;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class AnalysisContext {
 
@@ -34,6 +37,39 @@ public class AnalysisContext {
     volatile SoftReference<DirectByteBufferData> directByteBufferData = new SoftReference<>(null);
 
     volatile SoftReference<LeakReportData> leakReportData= new SoftReference<>(null);
+
+    /**
+     * Cache for find_strings results, keyed by the MAT pattern actually used. Keying by pattern
+     * rather than caching every String in the heap keeps the retained set proportional to what was
+     * asked for, and still serves the common case of paging through one search result.
+     */
+    final ConcurrentHashMap<String, SoftReference<StringData>> stringsCache = new ConcurrentHashMap<>();
+
+    /** Cache for merge_shortest_paths IResultTree, keyed by the requested objectIds */
+    final ConcurrentHashMap<MergePathTreeCacheKey, SoftReference<IResultTree>> mergePathTreeCache = new ConcurrentHashMap<>();
+
+    /**
+     * Monitor for populating {@link #mergePathTreeCache}. Not the context monitor: this class is
+     * public and shared, so running a minutes-long BFS while holding its monitor would block
+     * unrelated code that locks on the context (e.g. the classLoaderExplorerData path).
+     * <p>
+     * This is a single lock rather than a per-key one, so the first BFS for one set of objectIds
+     * serializes the first BFS for any other set. That is an accepted trade-off for the paged UI
+     * callers, which rarely request different object sets concurrently; cache hits never take the
+     * lock. If concurrent distinct BFS runs become a requirement, switch to per-key memoization
+     * (e.g. a FutureTask per key) rather than widening this lock.
+     */
+    final Object mergePathTreeLock = new Object();
+
+    /** Cache for the final LeakReport Java object */
+    volatile SoftReference<LeakReport> leakReportCache = new SoftReference<>(null);
+
+    /**
+     * Monitor for building the leak report. leakhunter runs a full-heap BFS that can take minutes,
+     * so it must not be done while holding the context monitor, which is also used by the
+     * classLoaderExplorerData path and is lockable by any code holding this public context.
+     */
+    final Object leakReportLock = new Object();
 
     AnalysisContext(ISnapshot snapshot) {
         this.snapshot = snapshot;
@@ -87,6 +123,38 @@ public class AnalysisContext {
 
     static class LeakReportData {
         IResult result;
+    }
+
+    static class StringData {
+        IResultTree tree;
+        List<?> nodes;
+    }
+
+    static class MergePathTreeCacheKey {
+        final int[] objectIds;
+        final int hash;
+
+        MergePathTreeCacheKey(int[] objectIds) {
+            // Copy so the key is immune to later mutation of the caller's array, and sort so that
+            // the same object set requested in a different order still hits the cache. The
+            // merge_shortest_paths result does not depend on the input order, which only affects
+            // sibling enumeration order in the resulting tree, and no caller relies on that.
+            this.objectIds = objectIds.clone();
+            Arrays.sort(this.objectIds);
+            this.hash = Arrays.hashCode(this.objectIds);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof MergePathTreeCacheKey)) return false;
+            return Arrays.equals(objectIds, ((MergePathTreeCacheKey) o).objectIds);
+        }
+
+        @Override
+        public int hashCode() {
+            return hash;
+        }
     }
 
     @Override

--- a/analysis/heap-dump/impl/src/main/java/org/eclipse/jifa/hda/impl/HeapDumpAnalyzerImpl.java
+++ b/analysis/heap-dump/impl/src/main/java/org/eclipse/jifa/hda/impl/HeapDumpAnalyzerImpl.java
@@ -520,6 +520,9 @@ public class HeapDumpAnalyzerImpl implements HeapDumpAnalyzer {
         if (classLoaderExplorerData != null) {
             return classLoaderExplorerData;
         }
+        // The context monitor now guards only the short queries (this one and
+        // queryDirectByteBufferData); the BFS-backed caches in AnalysisContext have their own
+        // locks or need none, so they no longer block whoever locks on the context.
         //noinspection SynchronizationOnLocalVariableOrMethodParameter
         synchronized (context) {
             classLoaderExplorerData = context.classLoaderExplorerData.get();
@@ -781,10 +784,34 @@ public class HeapDumpAnalyzerImpl implements HeapDumpAnalyzer {
     @Override
     public PageView<TheString.Item> getStrings(String pattern, int page, int pageSize) {
         return $(() -> {
-            IResultTree tree = queryByCommand(context, "find_strings java.lang.String -pattern " +
-                                                       (pattern == null || pattern.equals("") ? ".*" : ".*" + pattern + ".*"));
-            List<?> strings = tree.getElements();
-            return PageViewBuilder.build(strings, new PagingRequest(page, pageSize), node -> {
+            // Let MAT do the matching: find_strings applies the pattern to the string value
+            // (IObject#getClassSpecificName), which is not what the result's first column exposes
+            // (that is the display name, i.e. "java.lang.String @ 0x... <value truncated at 256>").
+            // Filtering on the display name in Java would both match on class name and address and
+            // miss content beyond the truncation point.
+            String matPattern = pattern == null || pattern.isEmpty() ? ".*" : ".*" + pattern + ".*";
+            // Cache per pattern so that paging through one result set scans the heap only once.
+            // No locking: the query is idempotent, so a cold-start race at worst repeats the scan,
+            // whereas a lock held across a full-heap scan would stall every other search.
+            SoftReference<AnalysisContext.StringData> ref = context.stringsCache.get(matPattern);
+            AnalysisContext.StringData cachedData = ref != null ? ref.get() : null;
+            if (cachedData == null) {
+                // Pass the pattern as an argument instead of appending "-pattern <p>" to the
+                // command: the command string is tokenized on whitespace, so a spliced pattern
+                // containing a space would be parsed as several arguments and rejected.
+                Map<String, Object> args = new HashMap<>();
+                args.put("pattern", Pattern.compile(matPattern));
+                IResultTree tree = queryByCommand(context, "find_strings java.lang.String", args);
+                cachedData = new AnalysisContext.StringData();
+                cachedData.tree = tree;
+                cachedData.nodes = tree.getElements();
+                // Drop entries whose result has been reclaimed so the map does not keep growing.
+                context.stringsCache.values().removeIf(value -> value.get() == null);
+                context.stringsCache.put(matPattern, new SoftReference<>(cachedData));
+            }
+
+            IResultTree tree = cachedData.tree;
+            return PageViewBuilder.build(cachedData.nodes, new PagingRequest(page, pageSize), node -> {
                 TheString.Item item = new TheString.Item();
                 int id = tree.getContext(node).getObjectId();
                 item.setObjectId(id);
@@ -965,10 +992,30 @@ public class HeapDumpAnalyzerImpl implements HeapDumpAnalyzer {
             throw new CommonException("Unsupported grouping now");
         }
 
-        Map<String, Object> args = new HashMap<>();
-        args.put("objects", Helper.buildHeapObjectArgument(objectIds));
-
-        return queryByCommand(context, "merge_shortest_paths", args);
+        // Cache the BFS result by objectIds to avoid redundant O(N) graph traversals. The grouping
+        // is not part of the key because only FROM_GC_ROOTS reaches this point (guarded above).
+        AnalysisContext.MergePathTreeCacheKey cacheKey =
+                new AnalysisContext.MergePathTreeCacheKey(objectIds);
+        SoftReference<IResultTree> ref = context.mergePathTreeCache.get(cacheKey);
+        IResultTree cached = ref != null ? ref.get() : null;
+        if (cached != null) {
+            return cached;
+        }
+        synchronized (context.mergePathTreeLock) {
+            ref = context.mergePathTreeCache.get(cacheKey);
+            cached = ref != null ? ref.get() : null;
+            if (cached != null) {
+                return cached;
+            }
+            // Entries whose tree has been reclaimed still pin their key, which holds one int per
+            // requested object. Drop them here so the map does not keep growing across a session.
+            context.mergePathTreeCache.values().removeIf(value -> value.get() == null);
+            Map<String, Object> args = new HashMap<>();
+            args.put("objects", Helper.buildHeapObjectArgument(objectIds));
+            IResultTree tree = queryByCommand(context, "merge_shortest_paths", args);
+            context.mergePathTreeCache.put(cacheKey, new SoftReference<>(tree));
+            return tree;
+        }
     }
 
     private PageView<GCRootPath.MergePathToGCRootsTreeNode> buildMergePathRootsNode(AnalysisContext context,
@@ -1124,90 +1171,99 @@ public class HeapDumpAnalyzerImpl implements HeapDumpAnalyzer {
     @Override
     public LeakReport getLeakReport() {
         return $(() -> {
-            AnalysisContext.LeakReportData data = context.leakReportData.get();
-            if (data == null) {
-                synchronized (context) {
-                    data = context.leakReportData.get();
-                    if (data == null) {
-                        IResult result = queryByCommand(context, "leakhunter");
-                        data = new AnalysisContext.LeakReportData();
-                        data.result = result;
-                        context.leakReportData = new SoftReference<>(data);
-                    }
-                }
+            // Check final LeakReport cache first (avoids BFS + object rebuild)
+            LeakReport cached = context.leakReportCache.get();
+            if (cached != null) {
+                return cached;
             }
-            IResult result = data.result;
-            LeakReport report = new LeakReport();
-            if (result instanceof TextResult) {
-                report.setInfo(((TextResult) result).getText());
-            } else if (result instanceof SectionSpec) {
-                report.setUseful(true);
-                SectionSpec sectionSpec = (SectionSpec) result;
-                report.setName(sectionSpec.getName());
-                List<Spec> specs = sectionSpec.getChildren();
-                for (int i = 0; i < specs.size(); i++) {
-                    QuerySpec spec = (QuerySpec) specs.get(i);
-                    String name = spec.getName();
-                    if (name == null || name.isEmpty()) {
-                        continue;
-                    }
-                    // LeakHunterQuery_Overview
-                    if (name.startsWith("Overview")) {
-                        IResultPie irtPie = (IResultPie) spec.getResult();
-                        List<? extends IResultPie.Slice> pieSlices = irtPie.getSlices();
+            synchronized (context.leakReportLock) {
+                cached = context.leakReportCache.get();
+                if (cached != null) {
+                    return cached;
+                }
 
-                        List<LeakReport.Slice> slices = new ArrayList<>();
-                        for (IResultPie.Slice slice : pieSlices) {
-                            slices.add(
-                                    new LeakReport.Slice(slice.getLabel(),
-                                                         Helper.fetchObjectId(slice.getContext()),
-                                                         slice.getValue(), slice.getDescription()));
+                AnalysisContext.LeakReportData data = context.leakReportData.get();
+                if (data == null) {
+                    IResult result = queryByCommand(context, "leakhunter");
+                    data = new AnalysisContext.LeakReportData();
+                    data.result = result;
+                    context.leakReportData = new SoftReference<>(data);
+                }
+                IResult result = data.result;
+                LeakReport report = new LeakReport();
+                if (result instanceof TextResult) {
+                    report.setInfo(((TextResult) result).getText());
+                } else if (result instanceof SectionSpec) {
+                    report.setUseful(true);
+                    SectionSpec sectionSpec = (SectionSpec) result;
+                    report.setName(sectionSpec.getName());
+                    List<Spec> specs = sectionSpec.getChildren();
+                    for (int i = 0; i < specs.size(); i++) {
+                        QuerySpec spec = (QuerySpec) specs.get(i);
+                        String name = spec.getName();
+                        if (name == null || name.isEmpty()) {
+                            continue;
                         }
-                        report.setSlices(slices);
-                    }
-                    // LeakHunterQuery_ProblemSuspect
-                    // LeakHunterQuery_Hint
-                    else if (name.startsWith("Problem Suspect") || name.startsWith("Hint")) {
-                        LeakReport.Record suspect = new LeakReport.Record();
-                        suspect.setIndex(i);
-                        suspect.setName(name);
-                        CompositeResult cr = (CompositeResult) spec.getResult();
-                        List<CompositeResult.Entry> entries = cr.getResultEntries();
-                        for (CompositeResult.Entry entry : entries) {
-                            String entryName = entry.getName();
-                            if (entryName == null || entryName.isEmpty()) {
-                                IResult r = entry.getResult();
-                                if (r instanceof QuerySpec &&
-                                    // LeakHunterQuery_ShortestPaths
-                                    ((QuerySpec) r).getName().equals("Shortest Paths To the Accumulation Point")) {
-                                    IResultTree tree = (IResultTree) ((QuerySpec) r).getResult();
-                                    RefinedResultBuilder builder = new RefinedResultBuilder(
-                                            new SnapshotQueryContext(context.snapshot), tree);
-                                    RefinedTree rst = (RefinedTree) builder.build();
-                                    List<?> elements = rst.getElements();
-                                    List<LeakReport.ShortestPath> paths = new ArrayList<>();
-                                    suspect.setPaths(paths);
-                                    for (Object row : elements) {
-                                        paths.add(buildPath(context.snapshot, rst, row));
+                        // LeakHunterQuery_Overview
+                        if (name.startsWith("Overview")) {
+                            IResultPie irtPie = (IResultPie) spec.getResult();
+                            List<? extends IResultPie.Slice> pieSlices = irtPie.getSlices();
+
+                            List<LeakReport.Slice> slices = new ArrayList<>();
+                            for (IResultPie.Slice slice : pieSlices) {
+                                slices.add(
+                                        new LeakReport.Slice(slice.getLabel(),
+                                                             Helper.fetchObjectId(slice.getContext()),
+                                                             slice.getValue(), slice.getDescription()));
+                            }
+                            report.setSlices(slices);
+                        }
+                        // LeakHunterQuery_ProblemSuspect
+                        // LeakHunterQuery_Hint
+                        else if (name.startsWith("Problem Suspect") || name.startsWith("Hint")) {
+                            LeakReport.Record suspect = new LeakReport.Record();
+                            suspect.setIndex(i);
+                            suspect.setName(name);
+                            CompositeResult cr = (CompositeResult) spec.getResult();
+                            List<CompositeResult.Entry> entries = cr.getResultEntries();
+                            for (CompositeResult.Entry entry : entries) {
+                                String entryName = entry.getName();
+                                if (entryName == null || entryName.isEmpty()) {
+                                    IResult r = entry.getResult();
+                                    if (r instanceof QuerySpec &&
+                                        // LeakHunterQuery_ShortestPaths
+                                        ((QuerySpec) r).getName().equals("Shortest Paths To the Accumulation Point")) {
+                                        IResultTree tree = (IResultTree) ((QuerySpec) r).getResult();
+                                        RefinedResultBuilder builder = new RefinedResultBuilder(
+                                                new SnapshotQueryContext(context.snapshot), tree);
+                                        RefinedTree rst = (RefinedTree) builder.build();
+                                        List<?> elements = rst.getElements();
+                                        List<LeakReport.ShortestPath> paths = new ArrayList<>();
+                                        suspect.setPaths(paths);
+                                        for (Object row : elements) {
+                                            paths.add(buildPath(context.snapshot, rst, row));
+                                        }
                                     }
                                 }
+                                // LeakHunterQuery_Description
+                                // LeakHunterQuery_Overview
+                                else if ((entryName.startsWith("Description") || entryName.startsWith("Overview"))) {
+                                    TextResult desText = (TextResult) entry.getResult();
+                                    suspect.setDesc(desText.getText());
+                                }
                             }
-                            // LeakHunterQuery_Description
-                            // LeakHunterQuery_Overview
-                            else if ((entryName.startsWith("Description") || entryName.startsWith("Overview"))) {
-                                TextResult desText = (TextResult) entry.getResult();
-                                suspect.setDesc(desText.getText());
+                            List<LeakReport.Record> records = report.getRecords();
+                            if (records == null) {
+                                report.setRecords(records = new ArrayList<>());
                             }
+                            records.add(suspect);
                         }
-                        List<LeakReport.Record> records = report.getRecords();
-                        if (records == null) {
-                            report.setRecords(records = new ArrayList<>());
-                        }
-                        records.add(suspect);
                     }
                 }
+
+                context.leakReportCache = new SoftReference<>(report);
+                return report;
             }
-            return report;
         });
     }
 

--- a/analysis/heap-dump/impl/src/test/java/org/eclipse/jifa/hda/impl/TestHeapDumpAnalyzerImpl.java
+++ b/analysis/heap-dump/impl/src/test/java/org/eclipse/jifa/hda/impl/TestHeapDumpAnalyzerImpl.java
@@ -16,6 +16,7 @@ import com.sun.management.HotSpotDiagnosticMXBean;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FileUtils;
 import org.eclipse.jifa.analysis.listener.ProgressListener;
+import org.eclipse.jifa.common.domain.vo.PageView;
 import org.eclipse.jifa.hda.api.HeapDumpAnalyzer;
 import org.eclipse.jifa.hda.api.Model;
 import org.eclipse.jifa.hda.api.SearchType;
@@ -31,8 +32,24 @@ import java.nio.file.Path;
 import java.util.Collections;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 @Slf4j
 public class TestHeapDumpAnalyzerImpl {
+
+    /** Regex-safe marker searched for by the getStrings tests. */
+    private static final String SENTINEL = "JIFA_GETSTRINGS_SENTINEL_c4f1";
+
+    /**
+     * Offset of {@link #SENTINEL} inside {@link #SENTINEL_HOLDER}: past the 256 characters that
+     * survive in an object's display name, but within the 1024 that MAT resolves as its value.
+     */
+    private static final int SENTINEL_OFFSET = 300;
+
+    /** Kept in a field so that the string stays reachable in the dump taken below. */
+    @SuppressWarnings("unused")
+    private static final String SENTINEL_HOLDER = "x".repeat(SENTINEL_OFFSET) + SENTINEL;
 
     private static Path DIRECTORY;
 
@@ -160,6 +177,41 @@ public class TestHeapDumpAnalyzerImpl {
     @Test
     public void testGetStrings() {
         ANALYZER.getStrings("abc", 1, 10);
+    }
+
+    /**
+     * find_strings must match the string value, not the display name. Matching the display name
+     * would make every String match its own class name and address.
+     */
+    @Test
+    public void testGetStringsDoesNotMatchDisplayNamePrefix() {
+        int all = ANALYZER.getStrings("", 1, 10).getTotalSize();
+        assertTrue(all > 0, "the dump is expected to contain strings");
+        assertTrue(ANALYZER.getStrings("java\\.lang\\.String @ 0x", 1, 10).getTotalSize() < all,
+                   "searching the display name prefix must not match every string");
+    }
+
+    /**
+     * The pattern must be matched against the whole string value. MAT resolves the value up to
+     * 1024 characters, whereas the display name exposed as the result's first column truncates it
+     * at 256, so the string holding the sentinel past that point is reported with a label that does
+     * not contain the sentinel at all. Such a hit can only be produced by matching the value, which
+     * is what makes this a regression guard against filtering on the label instead.
+     */
+    @Test
+    public void testGetStringsMatchesValueBeyondDisplayNameTruncation() {
+        PageView<Model.TheString.Item> hits = ANALYZER.getStrings(SENTINEL, 1, 100);
+        assertTrue(hits.getData().stream().anyMatch(item -> !item.getLabel().contains(SENTINEL)),
+                   "expected a hit whose label does not contain the sentinel, i.e. the string " +
+                   "holding it at offset " + SENTINEL_OFFSET + ", got: " + hits.getData());
+    }
+
+    /** Paging must be served from the same result set, i.e. sizes stay stable across pages. */
+    @Test
+    public void testGetStringsPagingIsStable() {
+        PageView<Model.TheString.Item> first = ANALYZER.getStrings("java", 1, 5);
+        PageView<Model.TheString.Item> second = ANALYZER.getStrings("java", 2, 5);
+        assertEquals(first.getTotalSize(), second.getTotalSize());
     }
 
     @Test


### PR DESCRIPTION
…port results

Problem: Three HeapDump operations redundantly re-execute expensive MAT computations on every call within the same session:

1. getMergePathToGCRoots - @Cacheable on queryByCommand always misses because Helper.buildHeapObjectArgument returns a new anonymous IHeapObjectArgument instance each time; Cache.CacheKey uses Arrays.equals which falls back to reference identity → never matches. Each miss triggers a full-heap BFS (O(N) graph traversal + disk I/O).

2. getLeakReport - only the raw MAT IResult was cached (SoftReference), but the LeakReport Java object and its embedded Shortest Paths (which internally trigger additional BFS calls) were rebuilt from scratch on every invocation.

3. getStrings - called the 2-arg queryByCommand(context, command) which bypasses the @Cacheable 3-arg version entirely, causing a full-heap string scan on every call with any pattern.

Solution: Add explicit SoftReference-based caches in AnalysisContext, bypassing the broken @Cacheable mechanism:

- MergePathTreeCacheKey with proper Arrays.equals/hashCode for caching merge_shortest_paths IResultTree by objectIds
- StringData cache for find_strings full result (".*" pattern), with Java-side regex filtering for specific patterns
- cachedLeakReport SoftReference<LeakReport> for the final built object, avoiding repeated BFS + object reconstruction

All caches use double-checked locking with synchronized(context) for thread safety, and SoftReference to allow GC under memory pressure.